### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ bash -c 'sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusi
 ```
 #### Step 2 — Install Core Dependencies (all DEs)
 ```bash
-sudo dnf install -y \
+sudo dnf install -y --skip-unavailable \
   gstreamer1 \
   gstreamer1-plugins-base \
   gstreamer1-plugins-bad-free \
   gstreamer1-plugins-bad-freeworld \
   gstreamer1-plugins-ugly \
   gstreamer1-plugin-libav \
-  gstreamer1-plugin-pipewire \
   pipewire \
   pipewire-gstreamer \
   python3-dbus \


### PR DESCRIPTION
meow meow

## Summary by Sourcery

Documentation:
- Document using dnf with --skip-unavailable when installing core multimedia dependencies on Fedora and drop an explicit gstreamer1-pipewire package from the example command.