### PR TITLE
fixed some issues with black screen on arch linux hypr and movbile

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/sdk/

--- a/android/app/src/main/java/com/example/monitorize/StreamReceiver.kt
+++ b/android/app/src/main/java/com/example/monitorize/StreamReceiver.kt
@@ -53,6 +53,7 @@ class StreamReceiver(
             val buf = ByteArray(4 * 1024 * 1024)
             var writePos = 0
             val readBuf = ByteArray(128 * 1024)  // larger reads = fewer syscalls
+            val accumulator = java.io.ByteArrayOutputStream()
 
             while (running) {
                 val bytesRead = input.read(readBuf)
@@ -74,8 +75,15 @@ class StreamReceiver(
                     val sc1 = findStartCode(buf, readStart, writePos)
                     if (sc1 < 0) break
 
+                    // Calculate start code length at sc1 to properly offset search for next start code
+                    val sc1Len = if (sc1 + 3 < writePos &&
+                                     buf[sc1] == 0.toByte() &&
+                                     buf[sc1 + 1] == 0.toByte() &&
+                                     buf[sc1 + 2] == 0.toByte() &&
+                                     buf[sc1 + 3] == 1.toByte()) 4 else 3
+
                     // Find next start code
-                    val sc2 = findStartCode(buf, sc1 + 4, writePos)
+                    val sc2 = findStartCode(buf, sc1 + sc1Len, writePos)
                     if (sc2 < 0) {
                         // Incomplete NAL — shift remaining data to front and wait
                         val remaining = writePos - sc1
@@ -88,7 +96,19 @@ class StreamReceiver(
                     }
 
                     // Complete NAL unit: [sc1 .. sc2)
-                    decoder.feedChunk(buf, sc1, sc2 - sc1)
+                    val naluSize = sc2 - sc1
+                    val naluType = buf[sc1 + sc1Len].toInt() and 0x1F
+
+                    // Accumulate the NAL unit
+                    accumulator.write(buf, sc1, naluSize)
+
+                    // If it is a slice (1 = non-IDR/P-slice, 5 = IDR/I-slice), flush the accumulated frame
+                    if (naluType == 1 || naluType == 5) {
+                        val frameData = accumulator.toByteArray()
+                        decoder.feedChunk(frameData, 0, frameData.size)
+                        accumulator.reset()
+                    }
+
                     readStart = sc2
                 }
 
@@ -116,7 +136,7 @@ class StreamReceiver(
      * Returns the index of the start code, or -1 if not found before [limit]-3.
      */
     private fun findStartCode(buf: ByteArray, from: Int, limit: Int): Int {
-        val end = limit - 3
+        val end = limit - 2
         var i = from
         while (i < end) {
             // Fast skip: if current byte is not 0, skip ahead
@@ -124,7 +144,11 @@ class StreamReceiver(
                 i++
                 continue
             }
-            if (buf[i + 1].toInt() == 0 && buf[i + 2].toInt() == 0 && buf[i + 3].toInt() == 1) {
+            if (buf[i + 1].toInt() == 0 && buf[i + 2].toInt() == 1) {
+                // Check if there is an extra leading 0 before it
+                if (i > from && buf[i - 1].toInt() == 0) {
+                    return i - 1
+                }
                 return i
             }
             i++

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Use the Android Studio bundled JDK 21.
 # The system default (Java 25) causes Kotlin compiler to crash because the
 # embedded IntelliJ JavaVersion parser cannot parse "25.x" version strings.
-org.gradle.java.home=/opt/android-studio/jbr
+org.gradle.java.home=/usr/lib/jvm/java-17-openjdk
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Use the Android Studio bundled JDK 21.
 # The system default (Java 25) causes Kotlin compiler to crash because the
 # embedded IntelliJ JavaVersion parser cannot parse "25.x" version strings.
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/linux/pipeline_builder.py
+++ b/linux/pipeline_builder.py
@@ -44,7 +44,7 @@ def _cpu_encoder_params(bitrate, key_int):
     return (
         f"x264enc tune=zerolatency speed-preset=ultrafast bitrate={bitrate} "
         f"key-int-max={key_int} byte-stream=true "
-        f"option-string=\"bframes=0:ref=1:sliced-threads=1:"
+        f"option-string=\"bframes=0:ref=1:sliced-threads=0:"                #trying single slice instead of 4
         f"rc-lookahead=0:sync-lookahead=0:threads=4:"
         f"vbv-bufsize=500:vbv-maxrate={bitrate}:intra-refresh=1\""
     )


### PR DESCRIPTION
This is a fix for some bugs when starting the app 


TLDR: android parser only had 4 byte code checking 

buit for some it was pushing 3 byte intial code strings

it is a very short explanation it had multiple issues which are now been fixed :D

## Summary by Sourcery

Fix video start-code parsing and frame assembly for Android stream receiver and adjust related platform configurations.

Bug Fixes:
- Handle both 3-byte and 4-byte H.264 start codes when parsing NAL units to avoid black screens and startup issues.
- Accumulate NAL units into complete frames before feeding them to the decoder to prevent incomplete frame decoding issues.
- Update H.264 start code detection bounds to correctly identify 3-byte and 4-byte start codes.

Enhancements:
- Adjust x264 encoder configuration on Linux to use a single slice instead of sliced threads for improved compatibility or quality.

Build:
- Change Android Gradle Java home to use the system Java 17 OpenJDK instead of the Android Studio bundled JBR.