### PR TITLE
minor bug fixes

### DIFF
--- a/linux/input_bridge/daemon.py
+++ b/linux/input_bridge/daemon.py
@@ -12,6 +12,8 @@ from .uinput_backend import UInputBackend
 
 log = logging.getLogger("TouchDaemon")
 
+UINPUT_DESKTOPS = ("kde", "gnome", "hyprland", "sway")
+
 
 class InputDaemon:
     def __init__(
@@ -23,9 +25,7 @@ class InputDaemon:
         self.wifi = wifi
         self.udp_host = udp_host
         self.udp_port = udp_port
-        self.stylus_features = stylus_features and self.de in (
-            "kde", "gnome", "hyprland", "sway"
-        )
+        self.stylus_features = stylus_features and self.de in UINPUT_DESKTOPS
         self.geometry = Geometry(self.de, width, height)
         self.backend = UInputBackend(self.geometry, self.shutdown)
         self.dispatcher = InputDispatcher(self.backend, stylus_only)

--- a/linux/input_bridge/geometry.py
+++ b/linux/input_bridge/geometry.py
@@ -81,10 +81,13 @@ class Geometry:
             output = kde_virtual_output(outputs)
             value = output.get("rotation", 1) if output else 1
             key = str(value).strip().lower()
-            return {
+            rotations = {
                 "1": 0, "2": 270, "4": 180, "8": 90,
                 "none": 0, "left": 270, "inverted": 180, "right": 90,
-            }.get(key, 0)
+            }
+            if key not in rotations:
+                log.warning("Unknown KDE output rotation %r; using 0 degrees", value)
+            return rotations.get(key, 0)
         return 0
 
     def _fallback_rect(self):

--- a/linux/test_input_bridge.py
+++ b/linux/test_input_bridge.py
@@ -225,7 +225,7 @@ class DispatcherTest(unittest.TestCase):
 
 class DaemonStartupTest(unittest.TestCase):
     def test_all_desktops_use_uinput_backend(self):
-        for de in ("kde", "gnome", "hyprland", "sway"):
+        for de in daemon_module.UINPUT_DESKTOPS:
             daemon = daemon_module.InputDaemon(100, 100, de=de)
             self.assertIsInstance(daemon.backend, UInputBackend)
 


### PR DESCRIPTION
## Summary by Sourcery

Handle unknown KDE rotation values more robustly and centralize desktop environment configuration for stylus features and tests.

Bug Fixes:
- Prevent crashes or misbehavior when KDE reports an unexpected rotation value by defaulting to 0 degrees and logging a warning.

Enhancements:
- Extract supported uinput desktop environments into a shared constant used by the daemon initialization and tests.

Tests:
- Update daemon startup tests to rely on the shared uinput desktop list constant instead of duplicating desktop names.