### PR TITLE
changes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 > **Project Status: In beta & Actively Being Developed**
-> Core pipeline is fully functional on KDE and Hyprland. Sway support is available and GNOME support is experimental.
+> Fully functional on KDE and Hyprland. Sway and GNOME support is experimental.
 
 ---
 
@@ -23,43 +23,34 @@
 
 ## 📖 Overview
 
-**Monitorize** turns your Android tablet into a secondary monitor for your Linux desktop.
+**Monitorize** turns your Android tablet, Laptop, PC into a secondary monitor for your Linux desktop.
 
-Supported desktop environments are KDE Plasma, Hyprland, and Sway. GNOME is experimental.
-
-The pipeline is:
-
-### ✨ What You Get
-
-- A **High resolution** and **High FPS** second display.
-- **USB Mode** for lowest latency and most stable quality
-- **Wi-Fi Mode (Work In Progress)** for higher bitrates and multimonitor setups.
-- **User friendly desktop app made with pyqt** to guide you through.
-- **Android app** with a simple UI.
+Supported desktop environments are KDE Plasma, Hyprland. Sway and GNOME is experimental.
 
 ---
 
-## 🛠️ Requirements
+## 🛠️ Requirements:
+
+| Android               | Desktop                                         |
+| --------------------- | ----------------------------------------------- |
+| Android 9+            | KDE (6.7+), Hyprland, Sway, Gnome(experimental) |
+| Wi-Fi / USB Debugging | Tested on: Arch, fedora.                        |
+
+---
 
 ### 📦 Dependencies (Must Do)
 
-> **Note:** Python packages (`PyQt6`, `evdev`, `zeroconf`) are automatically installed inside a virtual environment when you run `install.sh`. You only need to install the system-level packages listed below.
-
-### Before running Monitorize, install the required packages for your distro and desktop environment. Follow your distro section below in order.
-
----
+###### Before running Monitorize, install the required packages for your distro and desktop environment.
 
 ## <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Fedora_icon_(2021).svg/960px-Fedora_icon_(2021).svg.png" height="28" alt="Fedora"> Fedora (DNF)
 
-### Step 1 — Enable RPM Fusion
-
-Fedora does not ship `x264enc` by default due to patent restrictions. Enable RPM Fusion first:
+### Step 1 — Enable RPM Fusion:
 
 ```bash
 bash -c 'sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm'
 ```
 
-### Step 2 — Install Core Dependencies (all DEs)
+### Step 2 — Install Core Dependencies:
 
 ```bash
 sudo dnf install -y --skip-unavailable \
@@ -76,9 +67,7 @@ sudo dnf install -y --skip-unavailable \
   android-tools
 ```
 
-### Step 3 — Input Permission (all DEs)
-
-Monitorize uses `/dev/uinput` for all Linux touch and stylus input. Enable uinput access before streaming:
+### Step 3 — Input Permission:
 
 ```bash
 echo 'KERNEL=="uinput", MODE="0660", GROUP="input"' | sudo tee /etc/udev/rules.d/99-uinput.rules
@@ -87,7 +76,7 @@ sudo usermod -aG input $USER
 # Log out and back in for group change to take effect
 ```
 
-### Step 4 — Desktop-Specific (Fedora)
+### Step 4 — Desktop-Specific (Fedora):
 
 ### KDE Plasma:
 
@@ -97,6 +86,8 @@ KDE support requires Plasma 6.7+
 sudo dnf install -y kscreen
 ```
 
+---
+
 ### GNOME (Experimental):
 
 No extra packages needed. However, you **must** disable hardware cursor rendering so the cursor is visible on the virtual monitor stream:
@@ -105,17 +96,11 @@ No extra packages needed. However, you **must** disable hardware cursor renderin
 gsettings set org.gnome.mutter.wayland disable-hardware-cursor true
 ```
 
-Log out and back in for the change to take effect. To revert:
+Log out and back in for the change to take effect. 
 
-```bash
-gsettings set org.gnome.mutter.wayland disable-hardware-cursor false
-```
+---
 
 ### Hyprland:
-
-Install the Hyprland XDG portal backend:
-
-#### Step 1:
 
 ```bash
 sudo dnf install -y \
@@ -125,9 +110,9 @@ sudo dnf install -y \
   wlr-randr
 ```
 
-### Sway:
+---
 
-Install the extra portal dependencies required by Monitorize:
+### Sway:
 
 ```bash
 sudo dnf install -y \
@@ -140,7 +125,7 @@ sudo dnf install -y \
 
 ## <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Arch_Linux_%22Crystal%22_icon.svg/330px-Arch_Linux_%22Crystal%22_icon.svg.png" height="28" alt="Arch Linux"> Arch Linux (Pacman)
 
-### Step 1 — Install Core Dependencies (all DEs)
+### Step 1 — Install Core Dependencies:
 
 ```bash
 sudo pacman -S --needed \
@@ -158,9 +143,7 @@ sudo pacman -S --needed \
   android-tools
 ```
 
-### Step 2 — Input Permission (all DEs)
-
-Monitorize uses `/dev/uinput` for all Linux touch and stylus input. Enable uinput access before streaming:
+### Step 2 — Input Permission:
 
 ```bash
 echo 'KERNEL=="uinput", MODE="0660", GROUP="input"' | sudo tee /etc/udev/rules.d/99-uinput.rules
@@ -173,11 +156,13 @@ sudo usermod -aG input $USER
 
 ### KDE Plasma:
 
-KDE support requires Plasma 6.7+
+KDE support requires Plasma 6.7 and above
 
 ```bash
 sudo pacman -S --needed kscreen
 ```
+
+---
 
 ### GNOME (Experimental):
 
@@ -187,15 +172,11 @@ No extra packages needed. However, you **must** disable hardware cursor renderin
 gsettings set org.gnome.mutter.wayland disable-hardware-cursor true
 ```
 
-Log out and back in for the change to take effect. To revert:
+Log out and back in for the change to take effect.
 
-```bash
-gsettings set org.gnome.mutter.wayland disable-hardware-cursor false
-```
+---
 
 ### Hyprland:
-
-#### Step 1 (specific dependencies)
 
 ```bash
 sudo pacman -S --needed \
@@ -204,6 +185,8 @@ sudo pacman -S --needed \
   xdg-desktop-portal-gtk \
   wlr-randr
 ```
+
+---
 
 ### Sway:
 
@@ -216,9 +199,7 @@ sudo pacman -S --needed \
 
 ## <img src="https://upload.wikimedia.org/wikipedia/commons/4/4a/Debian-OpenLogo.svg" height="28" alt="Debian"> Debian / Ubuntu (APT)
 
-### Step 1 — Enable non-free repos (Debian only, skip on Ubuntu)
-
-Debian restricts `gstreamer1.0-plugins-ugly` to the `non-free` component. Enable it first:
+### Step 1 — Enable non-free repos (Debian only, skip on Ubuntu):
 
 ```bash
 sudo apt install -y software-properties-common
@@ -226,7 +207,7 @@ sudo apt-add-repository non-free
 sudo apt update
 ```
 
-### Step 2 — Install Core Dependencies (all DEs)
+### Step 2 — Install Core Dependencies:
 
 ```bash
 sudo apt install -y \
@@ -253,9 +234,7 @@ sudo apt install -y \
   liboeffis-dev
 ```
 
-### Step 3 — Input Permission (all DEs)
-
-Monitorize uses `/dev/uinput` for all Linux touch and stylus input. Enable uinput access before streaming:
+### Step 3 — Input Permission:
 
 ```bash
 echo 'KERNEL=="uinput", MODE="0660", GROUP="input"' | sudo tee /etc/udev/rules.d/99-uinput.rules
@@ -266,13 +245,15 @@ sudo usermod -aG input $USER
 
 ### Step 4 — Desktop-Specific (Debian / Ubuntu)
 
-### KDE Plasma:
+### ~~KDE Plasma~~:
 
-KDE support requires Plasma 6.7+
+KDE support requires Plasma 6.7+ which isnt avalable yet on debian stable and ubuntu
 
 ```bash
 sudo apt install -y kscreen
 ```
+
+### ---
 
 ### GNOME (Experimental):
 
@@ -282,15 +263,11 @@ No extra packages needed. However, you **must** disable hardware cursor renderin
 gsettings set org.gnome.mutter.wayland disable-hardware-cursor true
 ```
 
-Log out and back in for the change to take effect. To revert:
+Log out and back in for the change to take effect.
 
-```bash
-gsettings set org.gnome.mutter.wayland disable-hardware-cursor false
-```
+---
 
 ### Hyprland:
-
-#### Step 1:
 
 ```bash
 sudo apt install -y \
@@ -300,7 +277,7 @@ sudo apt install -y \
   wlr-randr
 ```
 
-> **Note:** `xdg-desktop-portal-hyprland` may not be in older Debian/Ubuntu repos. If not found, build from source: [xdg-desktop-portal-hyprland](https://github.com/hyprwm/xdg-desktop-portal-hyprland)
+---
 
 ### Sway:
 
@@ -313,35 +290,21 @@ sudo apt install -y \
 
 ---
 
-## Running the Application
+## Running the Application:
 
-1.After running the application make sure you go to your display settings and configure the virtual display.
+1.After starting the stream in the desktop application make sure you go to your display settings and configure the newly created virtual display.
 
 2.When made changes to the virtual display's position or anything sometimes the stream crashes, it's normal just start the stream again (This won't work in gnome though).
 
-### Notes
+---
+
+### Notes:
 
 - Match the resolution and FPS set in the Android settings app to the desktop app settings.
 
 - If the USB device is not detected, make sure `android-tools` is installed and run:
   
-  ```bash
-  adb devices
-  ```
-  
   to confirm the device is connected.
-
-- Monitorize uses `/dev/uinput` for all Linux touch and stylus input on KDE, GNOME, Hyprland, and Sway. `Enable Stylus Features` exposes pressure, tilt, eraser, hover, and stylus buttons through the same uinput path. If uinput is unavailable, or the compositor cannot bind the device to the streamed output, input stops so it cannot target the wrong display.
-
-- Stylus input suppresses finger touch for 5 seconds after the last stylus event. The `Disable Touch and Only Enable Stylus` option drops all finger-touch input while keeping stylus/eraser input active.
-
-### Android Tablet
-
-| Requirement       | Notes                              |
-| ----------------- | ---------------------------------- |
-| Android 9+        | Tested on Samsung Galaxy Tab S7 FE |
-| USB Debugging     | Enable in Developer Options        |
-| 5GHz Wi-Fi (opt.) | Recommended if using Wi-Fi mode    |
 
 ---
 
@@ -383,17 +346,26 @@ Or:
 ## 🗺️ Roadmap
 
 - [x] Stable CPU encoder (Software encoder).
+
 - [x] Stable vaapi encoder
+
 - [x] Fix stream corruption.
+
 - [x] desktop GUI.
+
 - [x] Touch screen.
+
+- [x] Stylus support with pressure.
+
+- [x] Encrypted Wi-Fi mode.
+
+- [x] Sway DE (beta).
+- [x] use laptop as second screen.
+- [x] triple monitor setup.
 - [ ] Stable nvidia encoder (waiting for driver 610.x which implemented proper DMA BUF).
-- [ ] On Sway DE.
-- [x] Stylus support with pressure, tilt, eraser, hover, and stylus buttons via uinput.
-- [ ] Stable Wi-Fi mode (beta).
+- [ ] Stable gnome.
+
 - [ ] Flathub distribution.
-- [ ] use laptop as second screen.
-- [ ] multi monitor setup.
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

Update README to clarify supported platforms, reorganize requirements, and streamline setup and usage instructions.

Documentation:
- Clarify supported desktop environments and device types, marking Sway and GNOME as experimental and adding laptop/PC as supported secondary displays.
- Replace the feature list with a concise requirements table covering Android and desktop environments, including tested distros.
- Simplify and standardize dependency and input permission instructions across Fedora, Arch, and Debian/Ubuntu, adding clearer step labels and separators.
- Note the lack of current KDE Plasma 6.7+ support on Debian stable and Ubuntu while keeping installation instructions.
- Refine GNOME configuration notes, removing revert instructions and emphasizing the need to disable hardware cursors.
- Tighten Hyprland and Sway setup sections by removing redundant step headings and adding visual separators between environments.
- Clarify running instructions around starting the stream and configuring the new virtual display, and adjust notes on stream crashes and device detection.
- Update the roadmap to mark stylus support, encrypted Wi‑Fi mode, Sway, laptop/tri‑monitor support as completed and introduce a Stable GNOME item.