### PR TITLE
cleanup

### DIFF
--- a/linux/monitorize/input_bridge/geometry.py
+++ b/linux/monitorize/input_bridge/geometry.py
@@ -100,7 +100,7 @@ def write_gnome_input_mapping(edid, stylus_features=False):
     return True
 
 
-def gnome_input_node_is_mapped(device_node, bus=None, dbus=None, log_failure=False):
+def gnome_input_node_is_mapped(device_node, bus=None, dbus=None, log_failure=True):
     if not device_node:
         return False
     try:
@@ -368,15 +368,20 @@ class Geometry:
             return set()
         try:
             import dbus
-
+        except ImportError as exc:
+            log.debug("GNOME input mapping verification unavailable: %s", exc)
+            return set()
+        try:
             bus = dbus.SessionBus()
-        except Exception as exc:
+        except dbus.exceptions.DBusException as exc:
             log.debug("GNOME input mapping verification unavailable: %s", exc)
             return set()
         mapped = set()
         for device in devices:
             path = getattr(getattr(device, "device", None), "path", "")
-            if gnome_input_node_is_mapped(path, bus=bus, dbus=dbus):
+            if gnome_input_node_is_mapped(
+                path, bus=bus, dbus=dbus, log_failure=False
+            ):
                 mapped.add(os.path.basename(path))
         return mapped
 

--- a/linux/tests/test_input_bridge.py
+++ b/linux/tests/test_input_bridge.py
@@ -567,6 +567,7 @@ class GnomeGeometryTest(unittest.TestCase):
                 "/dev/input/event11",
                 bus=bus,
                 dbus=dbus,
+                log_failure=False,
             )
         )
 
@@ -592,8 +593,48 @@ class GnomeGeometryTest(unittest.TestCase):
                 "/dev/input/event11",
                 bus=bus,
                 dbus=dbus,
+                log_failure=False,
             )
         )
+
+    def test_gnome_input_node_mapping_failure_warns_by_default(self):
+        mapper = Mock()
+        mapper.GetDeviceMapping.side_effect = RuntimeError("not mapped")
+        bus = Mock()
+        bus.get_object.return_value = object()
+        dbus = types.SimpleNamespace(Interface=Mock(return_value=mapper))
+
+        with patch("monitorize.input_bridge.geometry.log") as log:
+            self.assertFalse(
+                geometry.gnome_input_node_is_mapped(
+                    "/dev/input/event11",
+                    bus=bus,
+                    dbus=dbus,
+                )
+            )
+
+        log.warning.assert_called_once()
+        log.debug.assert_not_called()
+
+    def test_gnome_input_node_mapping_failure_can_be_debug_only(self):
+        mapper = Mock()
+        mapper.GetDeviceMapping.side_effect = RuntimeError("not mapped")
+        bus = Mock()
+        bus.get_object.return_value = object()
+        dbus = types.SimpleNamespace(Interface=Mock(return_value=mapper))
+
+        with patch("monitorize.input_bridge.geometry.log") as log:
+            self.assertFalse(
+                geometry.gnome_input_node_is_mapped(
+                    "/dev/input/event11",
+                    bus=bus,
+                    dbus=dbus,
+                    log_failure=False,
+                )
+            )
+
+        log.debug.assert_called_once()
+        log.warning.assert_not_called()
 
     def test_gnome_verify_devices_reuses_session_bus(self):
         geom = geometry.Geometry("gnome", 1920, 1200)
@@ -621,6 +662,45 @@ class GnomeGeometryTest(unittest.TestCase):
             [call.kwargs["bus"] for call in is_mapped.call_args_list],
             [bus, bus],
         )
+        self.assertEqual(
+            [call.kwargs["log_failure"] for call in is_mapped.call_args_list],
+            [False, False],
+        )
+
+    def test_gnome_verify_devices_ignores_dbus_unavailable(self):
+        geom = geometry.Geometry("gnome", 1920, 1200)
+
+        with patch.dict("sys.modules", {"dbus": None}):
+            self.assertEqual(geom.verify_gnome_devices([]), set())
+
+    def test_gnome_verify_devices_ignores_dbus_session_failure(self):
+        geom = geometry.Geometry("gnome", 1920, 1200)
+
+        class FakeDBusException(Exception):
+            pass
+
+        dbus = types.SimpleNamespace(
+            SessionBus=Mock(side_effect=FakeDBusException("no session")),
+            exceptions=types.SimpleNamespace(DBusException=FakeDBusException),
+        )
+
+        with patch.dict("sys.modules", {"dbus": dbus}):
+            self.assertEqual(geom.verify_gnome_devices([]), set())
+
+    def test_gnome_verify_devices_does_not_hide_unexpected_session_errors(self):
+        geom = geometry.Geometry("gnome", 1920, 1200)
+
+        class FakeDBusException(Exception):
+            pass
+
+        dbus = types.SimpleNamespace(
+            SessionBus=Mock(side_effect=ValueError("bug")),
+            exceptions=types.SimpleNamespace(DBusException=FakeDBusException),
+        )
+
+        with patch.dict("sys.modules", {"dbus": dbus}):
+            with self.assertRaises(ValueError):
+                geom.verify_gnome_devices([])
 
     def test_gnome_verify_devices_returns_mapped_event_names(self):
         geom = geometry.Geometry("gnome", 1920, 1200)
@@ -630,7 +710,10 @@ class GnomeGeometryTest(unittest.TestCase):
         stylus = types.SimpleNamespace(
             device=types.SimpleNamespace(path="/dev/input/event11")
         )
-        dbus = types.SimpleNamespace(SessionBus=Mock(return_value=Mock()))
+        dbus = types.SimpleNamespace(
+            SessionBus=Mock(return_value=Mock()),
+            exceptions=types.SimpleNamespace(DBusException=RuntimeError),
+        )
 
         with (
             patch.dict("sys.modules", {"dbus": dbus}),


### PR DESCRIPTION
## Summary by Sourcery

Adjust GNOME input device verification to handle DBus availability more robustly and refine logging behavior for mapping failures.

Bug Fixes:
- Prevent GNOME device verification from failing when the dbus module is missing or a DBus session cannot be established.
- Ensure GNOME input node mapping is non-fatal and only logs debug messages when verification code opts out of warning-level logs.

Enhancements:
- Change GNOME input node mapping to warn on failures by default while allowing callers to request debug-only logging.
- Have GNOME device verification reuse a single DBus session bus and explicitly disable failure warnings when checking devices for mappings.

Tests:
- Extend GNOME input bridge tests to cover new default logging behavior, debug-only logging mode, DBus unavailability, expected DBus session failures, and propagation of unexpected session errors.