### PR TITLE
Testing

### DIFF
--- a/linux/monitorize/desktop/backend.py
+++ b/linux/monitorize/desktop/backend.py
@@ -142,7 +142,7 @@ class MonitorizeBackend(QObject):
 
     @pyqtProperty(bool, notify=secondStreamActiveChanged)
     def secondStreamActive(self):
-        return False
+        return self.streaming.third_active()
 
     @pyqtProperty("QVariant", notify=presetsChanged)
     def presets(self):

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+from functools import lru_cache
 
 from PyQt6.QtCore import QObject, QProcess, QTimer, pyqtSignal
 
@@ -15,6 +16,70 @@ from monitorize.config.settings import (
 )
 from monitorize.platform.utils import LINUX_DIR
 from monitorize.config.validation import normalize_host, sanitize_decoder, sanitize_port, valid_host, valid_port
+
+
+COMPRESSED_QUEUE = [
+    "queue", "max-size-buffers=3", "max-size-time=0", "max-size-bytes=4194304",
+]
+RAW_DROP_QUEUE = [
+    "queue", "max-size-buffers=1", "max-size-time=0", "max-size-bytes=0",
+    "leaky=downstream",
+]
+PARSED_H264_CAPS = "video/x-h264,stream-format=byte-stream,alignment=au"
+SINK_PROPS = {
+    "sync": "false",
+    "async": "false",
+    "qos": "true",
+    "enable-last-sample": "false",
+    "force-aspect-ratio": "false",
+    "max-lateness": "20000000",
+}
+SINK_EXTRA_PROPS = {
+    "xvimagesink": {"double-buffer": "true", "draw-borders": "true"},
+}
+SOFTWARE_DECODER_PROPS = {
+    "max-threads": "2",
+    "thread-type": "slice",
+    "output-corrupt": "false",
+    "discard-corrupted-frames": "true",
+    "automatic-request-sync-points": "true",
+}
+
+
+@lru_cache(maxsize=64)
+def _gst_element_properties(element):
+    try:
+        result = subprocess.run(
+            ["gst-inspect-1.0", element],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return set()
+    if result.returncode != 0:
+        return set()
+    properties = set()
+    in_properties = False
+    for line in result.stdout.splitlines():
+        if line.strip() == "Element Properties:":
+            in_properties = True
+            continue
+        if not in_properties:
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not line.startswith("  "):
+            break
+        name = stripped.split(":", 1)[0].strip()
+        if name:
+            properties.add(name)
+    return properties
+
+
+def _gst_has_property(element, prop):
+    return prop in _gst_element_properties(element)
 
 
 class ReceiverController(QObject):
@@ -44,6 +109,11 @@ class ReceiverController(QObject):
         self.stable_generation = None
         self.stable_process = None
         self.retry_generation = None
+        self.receiver_host = ""
+        self.receiver_port = 0
+        self.pipeline_fallback_used = False
+        self.sink_candidates = []
+        self.sink_index = 0
         self.stable_timer = QTimer(self)
         self.stable_timer.setSingleShot(True)
         self.stable_timer.timeout.connect(
@@ -80,7 +150,10 @@ class ReceiverController(QObject):
         self.fingerprint = fingerprint
         self.pairing_code = pairing_code
         self.decoder = decoder
-        self.sink = "glimagesink" if gst_has_element("glimagesink") else "autovideosink"
+        self.sink_candidates = self._sink_candidates()
+        self.sink_index = 0
+        self.sink = self.sink_candidates[0]
+        self.pipeline_fallback_used = False
         if decoder == "Hardware":
             hardware = next((
                 name for name in ("vah264dec", "vaapih264dec")
@@ -97,7 +170,7 @@ class ReceiverController(QObject):
             self.decoder_args = [hardware]
             self.decoder_label = f"VA-API {hardware}"
         else:
-            self.decoder_args = ["avdec_h264", "max-threads=1", "thread-type=slice"]
+            self.decoder_args = self._software_decoder_args()
             self.decoder_label = "Software avdec_h264"
         self.retry_count = 0
         self.retry_pending = False
@@ -143,6 +216,8 @@ class ReceiverController(QObject):
         generation = self.generation if generation is None else generation
         if self.stopping or generation != self.generation:
             return
+        self.receiver_host = host
+        self.receiver_port = port
         self.attempt_started = time.monotonic()
         self.process = QProcess(self)
         process = self.process
@@ -159,14 +234,66 @@ class ReceiverController(QObject):
         )
         args = [
             "-e", "tcpclientsrc", f"host={host}", f"port={port}", "!",
-            "h264parse", "!", "queue", "max-size-buffers=1",
-            "max-size-time=0", "max-size-bytes=0", "leaky=downstream", "!",
-            *self.decoder_args, "!", "queue", "max-size-buffers=1",
-            "max-size-time=0", "max-size-bytes=0", "leaky=downstream", "!",
-            self.sink, "sync=false",
+            "h264parse", "disable-passthrough=true", "config-interval=-1", "!",
+            PARSED_H264_CAPS, "!",
+            *COMPRESSED_QUEUE, "!",
+            *self.decoder_args, "!",
+            *RAW_DROP_QUEUE, "!",
+            *self._sink_args(self.sink),
         ]
         self.logAppended.emit(f"Decoder: {self.decoder_label}; sink: {self.sink}")
         self.process.start("gst-launch-1.0", args)
+
+    def _sink_candidates(self):
+        candidates = []
+        session = os.environ.get("XDG_SESSION_TYPE", "").lower()
+        if session == "wayland" or os.environ.get("WAYLAND_DISPLAY"):
+            candidates.extend(["gtkwaylandsink", "waylandsink"])
+        if session == "x11" or os.environ.get("DISPLAY"):
+            candidates.extend(["xvimagesink", "ximagesink"])
+        candidates.extend(["glimagesink", "autovideosink"])
+        seen = set()
+        available = []
+        for sink in candidates:
+            if sink in seen:
+                continue
+            seen.add(sink)
+            if sink == "autovideosink" or gst_has_element(sink):
+                available.append(sink)
+        return available or ["autovideosink"]
+
+    def _sink_args(self, sink):
+        props = dict(SINK_PROPS)
+        props.update(SINK_EXTRA_PROPS.get(sink, {}))
+        args = [sink]
+        for name, value in props.items():
+            if _gst_has_property(sink, name):
+                args.append(f"{name}={value}")
+        return args
+
+    def _software_decoder_args(self):
+        args = ["avdec_h264"]
+        for name, value in SOFTWARE_DECODER_PROPS.items():
+            if _gst_has_property("avdec_h264", name):
+                args.append(f"{name}={value}")
+        return args
+
+    def _use_receiver_fallback(self):
+        if self.pipeline_fallback_used:
+            return False
+        self.pipeline_fallback_used = True
+        if self.sink_index + 1 < len(self.sink_candidates):
+            self.sink_index += 1
+            self.sink = self.sink_candidates[self.sink_index]
+        self.decoder_args = self._software_decoder_args()
+        self.decoder_label = "Software avdec_h264"
+        self.logAppended.emit(
+            f"Receiver pipeline failed immediately; retrying with "
+            f"{self.decoder_label}; sink: {self.sink}"
+        )
+        self.process = None
+        self._launch_pipeline(self.receiver_host, self.receiver_port, self.generation)
+        return True
 
     def _started(self, process=None, generation=None):
         process = self.process if process is None else process
@@ -258,6 +385,14 @@ class ReceiverController(QObject):
         self.logAppended.emit(f"Receiver process exited (code {code})")
         self.stable_timer.stop()
         elapsed = time.monotonic() - self.attempt_started
+        if (
+            code
+            and not self.stopping
+            and not self.receiving
+            and elapsed < 2
+            and self._use_receiver_fallback()
+        ):
+            return
         max_retries = 30 if self.receiving else 10
         if (
             not self.stopping
@@ -291,6 +426,7 @@ class ReceiverController(QObject):
         self.process = self.tls_process = None
         self.tls_buffer = ""
         self.auth_failed = self.retry_pending = False
+        self.pipeline_fallback_used = False
         self.stable_generation = self.stable_process = self.retry_generation = None
         kill_patterns("gst-launch-1.0.*tcpclientsrc")
         self._uninhibit_sleep()

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -245,13 +245,13 @@ class ReceiverController(QObject):
         self.process.start("gst-launch-1.0", args)
 
     def _sink_candidates(self):
-        candidates = []
+        candidates = ["glimagesink"]
         session = os.environ.get("XDG_SESSION_TYPE", "").lower()
         if session == "wayland" or os.environ.get("WAYLAND_DISPLAY"):
-            candidates.extend(["gtkwaylandsink", "waylandsink"])
+            candidates.append("waylandsink")
         if session == "x11" or os.environ.get("DISPLAY"):
             candidates.extend(["xvimagesink", "ximagesink"])
-        candidates.extend(["glimagesink", "autovideosink"])
+        candidates.append("autovideosink")
         seen = set()
         available = []
         for sink in candidates:

--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -30,6 +30,7 @@ from monitorize.config.settings import (
 from monitorize.platform.utils import LINUX_DIR
 from monitorize.config.validation import (
     DEFAULT_PRIMARY_RESOLUTION,
+    DEFAULT_SECONDARY_RESOLUTION,
     sanitize_bitrate,
     sanitize_display_type,
     sanitize_encoder,
@@ -41,6 +42,8 @@ from monitorize.config.validation import (
 
 GNOME_LAYOUT_SAVE_INTERVAL_MS = 1000
 GNOME_LAYOUT_CHANGE_DEBOUNCE_MS = 750
+THIRD_STREAM_PUBLIC_PORT = 7114
+THIRD_STREAM_BACKEND_PORT = 7115
 GNOME_DISPLAY_CONFIG_SERVICE = "org.gnome.Mutter.DisplayConfig"
 GNOME_DISPLAY_CONFIG_PATH = "/org/gnome/Mutter/DisplayConfig"
 GNOME_DISPLAY_CONFIG_IFACE = "org.gnome.Mutter.DisplayConfig"
@@ -76,6 +79,11 @@ class StreamingController(QObject):
         self.streamer_has_pipewire_node = False
         self.kde_portal_terminal_error = False
         self.primary_ready = False
+        self.third_streamer = None
+        self.third_streaming = False
+        self.third_ready = False
+        self.third_generation = 0
+        self.third_gst_pids = set()
         self.encoder_profile = "Low Latency"
         self.runtime_general = None
         self.countdown_timer = QTimer(self)
@@ -184,6 +192,13 @@ class StreamingController(QObject):
         process.setWorkingDirectory(LINUX_DIR)
         if use_env:
             process.setProcessEnvironment(self.env)
+        process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        return process
+
+    def _new_third_process(self, env):
+        process = QProcess(self)
+        process.setWorkingDirectory(LINUX_DIR)
+        process.setProcessEnvironment(env)
         process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
         return process
 
@@ -364,6 +379,14 @@ class StreamingController(QObject):
         except ValueError:
             pass
 
+    def _track_third_gst_pid(self, line):
+        if "[GStreamer] PID:" not in line:
+            return
+        try:
+            self.third_gst_pids.add(int(line.split("PID:")[1].strip()))
+        except ValueError:
+            pass
+
     def _handle_kde_streamer_line(self, line, generation):
         if "[Portal] Creating session" in line:
             self._set_status("KDE portal opened — approve the virtual display.")
@@ -541,12 +564,148 @@ class StreamingController(QObject):
         self.gnome_layout_change_timer.start()
 
     def start_third(self, res, fps, bitrate, encoder, encoder_profile):
+        if self.de not in ("kde", "hyprland"):
+            self.logAppended.emit(
+                "STREAMER",
+                "[Third display] Portal picker is only enabled for KDE and Hyprland.",
+            )
+            self.secondStreamChanged.emit(False)
+            self._advertise()
+            return
+        if not self.streaming:
+            self.logAppended.emit(
+                "STREAMER",
+                "[Third display] Start the primary stream before adding a display.",
+            )
+            self.secondStreamChanged.emit(False)
+            self._advertise()
+            return
+        if not self.primary_ready:
+            self.logAppended.emit(
+                "STREAMER",
+                "[Third display] Primary stream is not ready yet.",
+            )
+            self.secondStreamChanged.emit(False)
+            self._advertise()
+            return
+        if self.third_streaming:
+            self.stop_third()
+
+        width, height = sanitize_resolution(res, DEFAULT_SECONDARY_RESOLUTION)
+        third_fps = sanitize_fps(fps)
+        third_bitrate = sanitize_bitrate(bitrate)
+        third_encoder = sanitize_encoder(encoder)
+        third_encoder_profile = sanitize_encoder_profile(encoder_profile)
+
+        env = QProcessEnvironment.systemEnvironment()
+        env.insert("PYTHONUNBUFFERED", "1")
+        env.insert("MONITORIZE_ENCODER", {
+            "NVIDIA NVENC (nvh264enc)": "nvidia",
+            "Intel/AMD VA-API (vah264enc)": "vaapi",
+        }.get(third_encoder, "cpu"))
+        env.insert("MONITORIZE_ENCODER_PROFILE", third_encoder_profile)
+        env.insert("MONITORIZE_PORTAL_SOURCE_TYPE", "1")
+        env.insert(
+            "MONITORIZE_PORTAL_SELECTOR_HINT",
+            "Choose the display to stream as Monitorize's third display.",
+        )
+        env.insert(
+            "MONITORIZE_PORT",
+            str(THIRD_STREAM_BACKEND_PORT if self.encrypted else THIRD_STREAM_PUBLIC_PORT),
+        )
+        env.insert(
+            "MONITORIZE_HOST",
+            "127.0.0.1" if (self.encrypted or not self.wifi) else "0.0.0.0",
+        )
+
+        self.third_generation += 1
+        generation = self.third_generation
+        self.third_width = width
+        self.third_height = height
+        self.third_fps = third_fps
+        self.third_bitrate = third_bitrate
+        self.third_encoder = third_encoder
+        self.third_encoder_profile = third_encoder_profile
+        self.third_ready = False
+        self.third_streaming = True
+        self.third_gst_pids.clear()
+        self.third_streamer = self._new_third_process(env)
+        process = self.third_streamer
+        process.readyReadStandardOutput.connect(
+            lambda: self._read_third_streamer(generation, process)
+        )
+        process.finished.connect(
+            lambda code, status: self._third_streamer_finished(
+                code, status, generation, process
+            )
+        )
+        process.errorOccurred.connect(
+            lambda _error: self._third_process_error(generation, process)
+        )
+        module = {
+            "kde": "monitorize.streaming.Streamer_kde",
+            "hyprland": "monitorize.streaming.Streamer_hyprland",
+        }[self.de]
+        process.start(sys.executable, [
+            "-m", module,
+            str(width), str(height), str(third_fps), str(third_bitrate),
+            "wifi" if self.wifi else "usb",
+        ])
+        self.secondStreamChanged.emit(True)
+        self._advertise()
         self.logAppended.emit(
             "STREAMER",
-            "[Third display] Backend disabled; UI is kept for future support.",
+            f"[Third display] Portal picker opened on port "
+            f"{THIRD_STREAM_PUBLIC_PORT if not self.encrypted else THIRD_STREAM_BACKEND_PORT}.",
         )
+
+    def _read_third_streamer(self, generation=None, process=None):
+        generation = self.third_generation if generation is None else generation
+        process = self.third_streamer if process is None else process
+        if generation != self.third_generation or process is not self.third_streamer:
+            return
+        raw = bytes(process.readAllStandardOutput()).decode(
+            "utf-8", errors="replace"
+        )
+        lines = raw.splitlines()
+        if lines:
+            message = "\n".join(f"[Third display] {line}" for line in lines)
+            if raw.endswith("\n"):
+                message += "\n"
+            self.logAppended.emit("STREAMER", message)
+        for line in lines:
+            self._track_third_gst_pid(line)
+            if "[Portal] Got PipeWire node=" in line:
+                self._set_status("Third display selected; stream pipeline starting...")
+            if "Setting pipeline to PLAYING" in line or "New clock:" in line:
+                if not self.third_ready:
+                    self.third_ready = True
+                    self._advertise()
+                    self._set_status("Third display streaming")
+
+    def _third_streamer_finished(
+        self, code, _status, generation=None, process=None
+    ):
+        if (
+            generation is not None
+            and (generation != self.third_generation or process is not self.third_streamer)
+        ):
+            return
+        self.logAppended.emit("STREAMER", f"[Third display] Streamer exited (code {code})")
+        self.third_streamer = None
+        self.third_streaming = False
+        self.third_ready = False
+        self.third_gst_pids.clear()
         self.secondStreamChanged.emit(False)
         self._advertise()
+
+    def _third_process_error(self, generation, process):
+        if generation != self.third_generation or process is not self.third_streamer:
+            return
+        self.logAppended.emit("STREAMER", f"[Third display] Process error: {process.errorString()}")
+
+    def third_active(self):
+        return self.third_streaming
 
     def _set_primary_ready(self, value):
         if self.primary_ready == value:
@@ -575,16 +734,38 @@ class StreamingController(QObject):
                 "stream_type": self.env.value("MONITORIZE_STREAM_TYPE"),
                 "use_encryption": self.encrypted,
             }
+        if self.third_streaming:
+            config["third"] = {
+                "enabled": True,
+                "resolution": f"{self.third_width}x{self.third_height}",
+                "fps": str(self.third_fps),
+                "bitrate": str(self.third_bitrate),
+                "encoder": self.third_encoder,
+                "encoder_profile": self.third_encoder_profile,
+            }
         return config
 
     def stop_third(self):
+        self.third_generation += 1
+        if self.third_streamer is not None:
+            stop_processes(self.third_streamer)
+        self.third_streamer = None
+        if self.third_gst_pids:
+            kill_tracked_pids(set(self.third_gst_pids))
+            self.third_gst_pids.clear()
+        kill_patterns(
+            f"gst-launch-1.0.*port={THIRD_STREAM_PUBLIC_PORT}",
+            f"gst-launch-1.0.*port={THIRD_STREAM_BACKEND_PORT}",
+        )
+        self.third_streaming = False
+        self.third_ready = False
         self._advertise()
         self.secondStreamChanged.emit(False)
-        self.logAppended.emit("STREAMER", "[Third display] Backend disabled.")
+        self.logAppended.emit("STREAMER", "[Third display] Stopped.")
 
     def _advertise(self, *_args):
         if self.streaming and self.wifi:
-            self.discovery.advertise(self.local_ip, self.encrypted, False)
+            self.discovery.advertise(self.local_ip, self.encrypted, self.third_ready)
 
     def stop(self):
         stopping_kde_portal = self._stopping_kde_portal_streamer()
@@ -602,6 +783,8 @@ class StreamingController(QObject):
         self.kde_portal_terminal_error = False
         self._set_primary_ready(False)
         self.runtime_general = None
+        if self.third_streaming or self.third_streamer is not None:
+            self.stop_third()
         portal_clean = True
         if stopping_kde_portal:
             save_current_virtual_layout(

--- a/linux/monitorize/qml/StreamingPage.qml
+++ b/linux/monitorize/qml/StreamingPage.qml
@@ -249,11 +249,11 @@ Item {
                 }
             }
 
-            // Add / Remove Third Display button (KDE only)
+            // Add / Remove Third Display button
             Button {
                 id: displayActionButton
                 text: backend.secondStreamActive ? "Remove Third Display" : "Add Third Display"
-                visible: backend.detectedDe === "kde"
+                visible: backend.detectedDe === "kde" || backend.detectedDe === "hyprland"
                 onClicked: {
                     if (backend.secondStreamActive) {
                         backend.stopSecondStream()
@@ -526,7 +526,7 @@ Item {
         }
     }
 
-    // ──── Add Display Popup (KDE only) ────
+    // Add Display Popup
     Popup {
         id: addDisplayPopup
         modal: true
@@ -562,7 +562,7 @@ Item {
             }
 
             Text {
-                text: "Third display controls are kept for future support.\nThe host-side display backend is currently disabled."
+                text: "Your desktop will open a screen-share picker.\nChoose the display to stream on the third-display port."
                 font.pixelSize: 12
                 color: theme.cardTextMuted
                 wrapMode: Text.Wrap

--- a/linux/monitorize/streaming/Streamer_hyprland.py
+++ b/linux/monitorize/streaming/Streamer_hyprland.py
@@ -15,11 +15,15 @@ bitrate = int(sys.argv[4]) if len(sys.argv) > 4 else 8000
 mode = sys.argv[5] if len(sys.argv) > 5 else "usb"
 server_mode = mode == "wifi"
 mirror = len(sys.argv) > 6 and sys.argv[6] == "mirror"
+selector_hint = os.environ.get(
+    "MONITORIZE_PORTAL_SELECTOR_HINT",
+    "Select your primary monitor in the picker."
+    if mirror else "Select the HEADLESS monitor in the picker.",
+)
 
 sys.exit(run_portal_streamer(
     "Hyprland",
-    "Select your primary monitor in the picker."
-    if mirror else "Select the HEADLESS monitor in the picker.",
+    selector_hint,
     width,
     height,
     fps,

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -365,21 +365,21 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIn("automatic-request-sync-points=true", args)
         self.assertIn("max-threads=2", args)
 
-    def test_sink_selection_prefers_native_wayland_then_gl(self):
+    def test_sink_selection_prefers_gl_before_wayland_fallback(self):
         controller = ReceiverController("kde", Mock())
         with (
             patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=True),
             patch(
                 "monitorize.desktop.receiver_controller.gst_has_element",
-                side_effect=lambda name: name in {"gtkwaylandsink", "glimagesink"},
+                side_effect=lambda name: name in {"waylandsink", "glimagesink"},
             ),
         ):
             self.assertEqual(
                 controller._sink_candidates(),
-                ["gtkwaylandsink", "glimagesink", "autovideosink"],
+                ["glimagesink", "waylandsink", "autovideosink"],
             )
 
-    def test_sink_selection_prefers_native_x11_then_gl(self):
+    def test_sink_selection_prefers_gl_before_x11_fallbacks(self):
         controller = ReceiverController("kde", Mock())
         with (
             patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"}, clear=True),
@@ -390,7 +390,7 @@ class ReceiverControllerTest(unittest.TestCase):
         ):
             self.assertEqual(
                 controller._sink_candidates(),
-                ["xvimagesink", "ximagesink", "glimagesink", "autovideosink"],
+                ["glimagesink", "xvimagesink", "ximagesink", "autovideosink"],
             )
 
     def test_sink_args_only_include_supported_properties_and_stretch(self):

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -322,20 +322,109 @@ class ValidationTest(unittest.TestCase):
 
 
 class ReceiverControllerTest(unittest.TestCase):
-    def test_pipeline_keeps_low_latency_queue_and_selected_decoder(self):
+    def test_pipeline_preserves_compressed_frames_and_drops_only_after_decode(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["vah264dec"]
         controller.decoder_label = "VA-API"
-        controller.sink = "glimagesink"
+        controller.sink = "xvimagesink"
         process = process_mock()
-        with patch("monitorize.desktop.receiver_controller.QProcess", return_value=process):
+        with (
+            patch("monitorize.desktop.receiver_controller.QProcess", return_value=process),
+            patch(
+                "monitorize.desktop.receiver_controller._gst_has_property",
+                return_value=True,
+            ),
+        ):
             controller._launch_pipeline("10.0.0.2", 7114)
         command, args = process.start.call_args.args
         self.assertEqual(command, "gst-launch-1.0")
         self.assertIn("vah264dec", args)
-        self.assertIn("leaky=downstream", args)
+        self.assertIn("disable-passthrough=true", args)
+        self.assertIn("config-interval=-1", args)
+        self.assertIn("video/x-h264,stream-format=byte-stream,alignment=au", args)
+        decoder_index = args.index("vah264dec")
+        first_queue_index = args.index("queue")
+        self.assertLess(first_queue_index, decoder_index)
+        self.assertNotIn("leaky=downstream", args[first_queue_index:decoder_index])
+        self.assertIn("leaky=downstream", args[decoder_index:])
         self.assertIn("sync=false", args)
+        self.assertIn("async=false", args)
+        self.assertIn("force-aspect-ratio=false", args)
         self.assertIn("port=7114", args)
+
+    def test_software_decoder_discards_corrupt_output_when_supported(self):
+        controller = ReceiverController("kde", Mock())
+        with patch(
+            "monitorize.desktop.receiver_controller._gst_has_property",
+            return_value=True,
+        ):
+            args = controller._software_decoder_args()
+        self.assertEqual(args[0], "avdec_h264")
+        self.assertIn("output-corrupt=false", args)
+        self.assertIn("discard-corrupted-frames=true", args)
+        self.assertIn("automatic-request-sync-points=true", args)
+        self.assertIn("max-threads=2", args)
+
+    def test_sink_selection_prefers_native_wayland_then_gl(self):
+        controller = ReceiverController("kde", Mock())
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+            patch(
+                "monitorize.desktop.receiver_controller.gst_has_element",
+                side_effect=lambda name: name in {"gtkwaylandsink", "glimagesink"},
+            ),
+        ):
+            self.assertEqual(
+                controller._sink_candidates(),
+                ["gtkwaylandsink", "glimagesink", "autovideosink"],
+            )
+
+    def test_sink_selection_prefers_native_x11_then_gl(self):
+        controller = ReceiverController("kde", Mock())
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"}, clear=True),
+            patch(
+                "monitorize.desktop.receiver_controller.gst_has_element",
+                side_effect=lambda name: name in {"xvimagesink", "ximagesink", "glimagesink"},
+            ),
+        ):
+            self.assertEqual(
+                controller._sink_candidates(),
+                ["xvimagesink", "ximagesink", "glimagesink", "autovideosink"],
+            )
+
+    def test_sink_args_only_include_supported_properties_and_stretch(self):
+        controller = ReceiverController("kde", Mock())
+        with patch(
+            "monitorize.desktop.receiver_controller._gst_has_property",
+            side_effect=lambda _element, prop: prop in {"sync", "force-aspect-ratio"},
+        ):
+            args = controller._sink_args("glimagesink")
+        self.assertEqual(args, ["glimagesink", "sync=false", "force-aspect-ratio=false"])
+
+    def test_immediate_receiver_failure_retries_once_with_fallback_pipeline(self):
+        controller = ReceiverController("kde", Mock())
+        controller.generation = 4
+        controller.host = "10.0.0.2"
+        controller.port = 7110
+        controller.receiver_host = "10.0.0.2"
+        controller.receiver_port = 7110
+        controller.sink_candidates = ["glimagesink", "autovideosink"]
+        controller.sink_index = 0
+        controller.sink = "glimagesink"
+        controller.decoder_args = ["vah264dec"]
+        controller.decoder_label = "VA-API"
+        controller.process = process_mock()
+        controller.attempt_started = __import__("time").monotonic()
+        with (
+            patch.object(controller, "_launch_pipeline") as launch,
+            patch.object(controller, "_software_decoder_args", return_value=["avdec_h264"]),
+        ):
+            controller._finished(1, None, controller.process, generation=4)
+        launch.assert_called_once_with("10.0.0.2", 7110, 4)
+        self.assertEqual(controller.sink, "autovideosink")
+        self.assertEqual(controller.decoder_args, ["avdec_h264"])
+        self.assertTrue(controller.pipeline_fallback_used)
 
     def test_stale_credentials_request_pairing_again(self):
         controller = ReceiverController("kde", Mock())

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -838,29 +838,184 @@ class StreamingControllerTest(unittest.TestCase):
         self.assertEqual(config["third"], {"enabled": False})
         self.assertTrue(config["general"]["enable_stylus_features"])
 
-    def test_third_display_backend_is_noop(self):
+    def test_active_configuration_includes_active_third_display_settings(self):
+        controller = self.kde_controller()
+        controller.encoder = "Intel/AMD VA-API (vah264enc)"
+        controller.encoder_profile = "Balanced"
+        controller.env.value.return_value = "Speed"
+        controller.third_streaming = True
+        controller.third_width = 1920
+        controller.third_height = 1080
+        controller.third_fps = 60
+        controller.third_bitrate = 12000
+        controller.third_encoder = "Software (CPU / x264enc)"
+        controller.third_encoder_profile = "Quality"
+
+        config = controller.active_configuration()
+
+        self.assertEqual(config["third"], {
+            "enabled": True,
+            "resolution": "1920x1080",
+            "fps": "60",
+            "bitrate": "12000",
+            "encoder": "Software (CPU / x264enc)",
+            "encoder_profile": "Quality",
+        })
+
+    def test_kde_third_display_uses_portal_monitor_picker(self):
         discovery = Mock()
         controller = StreamingController("kde", "10.0.0.1", discovery)
         controller.streaming = True
         controller.wifi = True
+        controller.encrypted = False
+        controller.primary_ready = True
+        events = []
+        controller.secondStreamChanged.connect(events.append)
+        process = process_mock()
+
+        with patch("monitorize.desktop.streaming_controller.QProcess", return_value=process):
+            controller.start_third(
+                "1920x1080", "60", "8000",
+                "Software (CPU / x264enc)", "Low Latency",
+            )
+
+        args = process.start.call_args.args[1]
+        env = process.setProcessEnvironment.call_args.args[0]
+        self.assertEqual(args[:2], ["-m", "monitorize.streaming.Streamer_kde"])
+        self.assertEqual(args[-1], "wifi")
+        self.assertEqual(env.value("MONITORIZE_PORTAL_SOURCE_TYPE"), "1")
+        self.assertEqual(env.value("MONITORIZE_PORT"), "7114")
+        self.assertNotEqual(env.value("MONITORIZE_PORTAL_SOURCE_TYPE"), "4")
+        self.assertEqual(events, [True])
+        discovery.advertise.assert_called_once_with("10.0.0.1", False, False)
+
+    def test_hyprland_third_display_uses_portal_monitor_picker(self):
+        controller = StreamingController("hyprland", "10.0.0.1", Mock())
+        controller.streaming = True
+        controller.wifi = True
+        controller.primary_ready = True
+        process = process_mock()
+
+        with patch("monitorize.desktop.streaming_controller.QProcess", return_value=process):
+            controller.start_third(
+                "1280x720", "30", "4000",
+                "Software (CPU / x264enc)", "Balanced",
+            )
+
+        args = process.start.call_args.args[1]
+        env = process.setProcessEnvironment.call_args.args[0]
+        self.assertEqual(args[:2], ["-m", "monitorize.streaming.Streamer_hyprland"])
+        self.assertEqual(args[2:6], ["1280", "720", "30", "4000"])
+        self.assertEqual(env.value("MONITORIZE_PORTAL_SOURCE_TYPE"), "1")
+        self.assertIn("third display", env.value("MONITORIZE_PORTAL_SELECTOR_HINT"))
+
+    def test_encrypted_third_display_uses_tls_backend_port(self):
+        controller = StreamingController("kde", "10.0.0.1", Mock())
+        controller.streaming = True
+        controller.wifi = True
+        controller.encrypted = True
+        controller.primary_ready = True
+        process = process_mock()
+
+        with patch("monitorize.desktop.streaming_controller.QProcess", return_value=process):
+            controller.start_third(
+                "1920x1080", "60", "8000",
+                "Software (CPU / x264enc)", "Low Latency",
+            )
+
+        env = process.setProcessEnvironment.call_args.args[0]
+        self.assertEqual(env.value("MONITORIZE_PORT"), "7115")
+        self.assertEqual(env.value("MONITORIZE_HOST"), "127.0.0.1")
+
+    def test_gnome_third_display_is_unsupported(self):
+        discovery = Mock()
+        controller = StreamingController("gnome", "10.0.0.1", discovery)
+        controller.streaming = True
+        controller.primary_ready = True
         events = []
         logs = []
         controller.secondStreamChanged.connect(events.append)
         controller.logAppended.connect(lambda label, message: logs.append((label, message)))
 
-        controller.start_third(
-            "1920x1080", "60", "8000", "Software", "Low Latency",
-        )
+        with patch("monitorize.desktop.streaming_controller.QProcess") as process:
+            controller.start_third(
+                "1920x1080", "60", "8000",
+                "Software (CPU / x264enc)", "Low Latency",
+            )
 
+        process.assert_not_called()
         self.assertEqual(events, [False])
-        discovery.advertise.assert_called_once_with("10.0.0.1", False, False)
         self.assertIn(
-            (
-                "STREAMER",
-                "[Third display] Backend disabled; UI is kept for future support.",
-            ),
+            ("STREAMER", "[Third display] Portal picker is only enabled for KDE and Hyprland."),
             logs,
         )
+
+    def test_third_availability_waits_for_pipeline_ready(self):
+        discovery = Mock()
+        controller = StreamingController("kde", "10.0.0.1", discovery)
+        controller.streaming = True
+        controller.wifi = True
+        controller.third_generation = 2
+        controller.third_streaming = True
+        process = process_mock()
+        process.readAllStandardOutput.return_value = (
+            b"[Portal] Got PipeWire node=42 fd=9\n"
+            b"New clock: GstSystemClock\n"
+        )
+        controller.third_streamer = process
+
+        controller._read_third_streamer(2, process)
+
+        self.assertTrue(controller.third_ready)
+        self.assertEqual(
+            discovery.advertise.call_args_list[-1].args,
+            ("10.0.0.1", False, True),
+        )
+
+    def test_stale_third_streamer_output_is_ignored(self):
+        controller = StreamingController("kde", "10.0.0.1", Mock())
+        controller.streaming = True
+        controller.third_generation = 2
+        controller.third_streaming = True
+        old_process = process_mock()
+        old_process.readAllStandardOutput.return_value = b"New clock: GstSystemClock\n"
+        controller.third_streamer = process_mock()
+
+        controller._read_third_streamer(1, old_process)
+
+        self.assertFalse(controller.third_ready)
+
+    def test_stale_third_streamer_exit_is_ignored(self):
+        controller = StreamingController("kde", "10.0.0.1", Mock())
+        controller.third_generation = 2
+        controller.third_streaming = True
+        old_process = process_mock()
+        controller.third_streamer = process_mock()
+
+        controller._third_streamer_finished(1, None, 1, old_process)
+
+        self.assertTrue(controller.third_streaming)
+
+    def test_stop_third_leaves_primary_streaming(self):
+        controller = StreamingController("kde", "10.0.0.1", Mock())
+        controller.streaming = True
+        controller.third_streaming = True
+        controller.third_ready = True
+        third_process = process_mock()
+        controller.third_streamer = third_process
+        controller.third_gst_pids = {123}
+
+        with (
+            patch("monitorize.desktop.streaming_controller.stop_processes") as stop,
+            patch("monitorize.desktop.streaming_controller.kill_tracked_pids") as kill_pids,
+            patch("monitorize.desktop.streaming_controller.kill_patterns"),
+        ):
+            controller.stop_third()
+
+        stop.assert_called_once_with(third_process)
+        kill_pids.assert_called_once_with({123})
+        self.assertTrue(controller.streaming)
+        self.assertFalse(controller.third_streaming)
 
     def test_stale_streamer_exit_does_not_restart_gnome(self):
         controller = StreamingController("gnome", "10.0.0.1", Mock())
@@ -2120,6 +2275,21 @@ class BackendFacadeTest(unittest.TestCase):
         self.assertIn("WifiPage {", usb_qml)
         self.assertIn("isWifi: false", usb_qml)
 
+    def test_streaming_page_shows_add_display_for_kde_and_hyprland(self):
+        qml_path = (
+            Path(__file__).resolve().parents[1]
+            / "monitorize"
+            / "qml"
+            / "StreamingPage.qml"
+        )
+        qml = qml_path.read_text(encoding="utf-8")
+        self.assertIn(
+            'backend.detectedDe === "kde" || backend.detectedDe === "hyprland"',
+            qml,
+        )
+        self.assertIn("Your desktop will open a screen-share picker.", qml)
+        self.assertNotIn("host-side display backend is currently disabled", qml)
+
     def test_qml_api_remains_exposed(self):
         with patch("monitorize.desktop.backend.get_local_ip", return_value="127.0.0.1"):
             backend = MonitorizeBackend("kde")
@@ -2142,6 +2312,15 @@ class BackendFacadeTest(unittest.TestCase):
             "saveCurrentPreset", "launchPreset", "renamePreset", "deletePreset",
             "isAutostartEnabled", "setAutostartEnabled",
         } <= methods)
+        backend.network_timer.stop()
+
+    def test_second_stream_active_comes_from_streaming_controller(self):
+        with patch("monitorize.desktop.backend.get_local_ip", return_value="127.0.0.1"):
+            backend = MonitorizeBackend("kde")
+        backend.streaming.third_streaming = True
+        self.assertTrue(backend.secondStreamActive)
+        backend.streaming.third_streaming = False
+        self.assertFalse(backend.secondStreamActive)
         backend.network_timer.stop()
 
     def test_backend_rejects_invalid_manual_connect(self):


### PR DESCRIPTION
## Summary by Sourcery

Add third-display streaming support for KDE and Hyprland with portal-based picker, enhance receiver robustness and sink selection, and expose the second stream to the QML frontend.

New Features:
- Enable third-display streaming via screen-share portals for KDE and Hyprland, including environment-driven encoder configuration and TLS-aware ports.
- Expose second-stream activity to the QML backend and UI, including updated StreamingPage controls and messaging.

Bug Fixes:
- Ensure receiver pipelines drop frames only after decode and improve handling of corrupt output in the software decoder.
- Prevent stale third-streamer output and exits from affecting current streaming state.

Enhancements:
- Refine receiver sink selection and sink argument configuration based on session type and GStreamer capabilities.
- Add automatic receiver-side fallback to software decoding and alternate sinks on immediate pipeline failure.
- Track and clean up GStreamer PIDs for third-display streams and ensure stop logic preserves the primary stream.
- Unify portal selector hints by passing them via environment for Hyprland streamers.

Tests:
- Extend unit tests for receiver pipelines, sink selection, and software decoder behavior.
- Add comprehensive tests for third-display lifecycle, readiness, encryption behavior, and UI integration.