### PR TITLE
reciever full screen windowless and android app bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ tmp/
 # ==============================
 #  Miscellaneous
 # ==============================
+/kwin/
+/mutter/
+
 # Gradle wrapper JAR (can be re-downloaded)
 gradle/wrapper/gradle-wrapper.jar
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
-val appVersionName = "0.2.4"
+val appVersionName = "0.2.5"
 
 fun versionCodeFromSemver(versionName: String): Int {
     val parts = versionName.split(".")

--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -1168,12 +1168,28 @@ fun StreamSurface(
                 isClickable = true
                 holder.addCallback(object : SurfaceHolder.Callback {
                     private var surfaceGeneration = 0L
+                    private var createdSurface: Surface? = null
 
                     override fun surfaceCreated(holder: SurfaceHolder) {
-                        surfaceGeneration = onSurfaceCreated(hostIp, holder.surface, width, height)
+                        createdSurface = holder.surface
                     }
-                    override fun surfaceChanged(h: SurfaceHolder, f: Int, w: Int, ht: Int) {}
-                    override fun surfaceDestroyed(h: SurfaceHolder) { onSurfaceDestroyed(surfaceGeneration) }
+                    override fun surfaceChanged(h: SurfaceHolder, f: Int, w: Int, ht: Int) {
+                        if (surfaceGeneration != 0L || w <= 0 || ht <= 0) {
+                            return
+                        }
+                        val surface = createdSurface ?: h.surface
+                        if (!surface.isValid) {
+                            return
+                        }
+                        surfaceGeneration = onSurfaceCreated(hostIp, surface, width, height)
+                    }
+                    override fun surfaceDestroyed(h: SurfaceHolder) {
+                        if (surfaceGeneration != 0L) {
+                            onSurfaceDestroyed(surfaceGeneration)
+                            surfaceGeneration = 0L
+                        }
+                        createdSurface = null
+                    }
                 })
                 fun requestLowLatencyInput(event: android.view.MotionEvent) {
                     when (event.actionMasked) {

--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -6,8 +6,9 @@ import android.net.wifi.WifiManager
 import android.util.Log
 import android.os.Build
 import android.os.Bundle
+import android.graphics.SurfaceTexture
 import android.view.Surface
-import android.view.SurfaceHolder
+import android.view.TextureView
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -218,7 +219,7 @@ class MainActivity : ComponentActivity() {
                                         clearPairingState(invokeCancel = true)
                                         restartApp()
                                     },
-                                    onSurfaceCreated = { ip, surface, w, h ->
+                                    onSurfaceCreated = { ip, surface, w, h, onFirstFrameRendered ->
                                         val generation = registerSurfaceCreated()
                                         coroutineScope.launch {
                                             val port = selectedDevice?.port ?: 7110
@@ -236,6 +237,7 @@ class MainActivity : ComponentActivity() {
                                                     decodedWidth = decodedW
                                                     decodedHeight = decodedH
                                                 },
+                                                onFirstFrameRendered = onFirstFrameRendered,
                                                 onDisconnect = {
                                                     runOnUiThread {
                                                         disconnectionMessage = "Connection stopped"
@@ -251,6 +253,9 @@ class MainActivity : ComponentActivity() {
                                         coroutineScope.launch {
                                             stopStream(surfaceGeneration = generation)
                                         }
+                                    },
+                                    onSurfaceRenderTimeout = {
+                                        status.value = "Video surface did not render; reconnect the receiver"
                                     },
                                     onInputEvent = { event, viewW, viewH -> inputSender?.send(event, viewW, viewH) }
                                 )
@@ -505,6 +510,7 @@ class MainActivity : ComponentActivity() {
         device: DiscoveredDevice?,
         onPairingRequired: ((String) -> Unit) -> Unit,
         onDecodedSize: (Int, Int) -> Unit,
+        onFirstFrameRendered: () -> Unit,
         onDisconnect: () -> Unit
     ) = streamMutex.withLock {
         if (!isSurfaceCurrent(surfaceGeneration)) {
@@ -522,15 +528,27 @@ class MainActivity : ComponentActivity() {
             activeStreamSession
         }
         val newWifiLock = acquireLowLatencyWifiLock()
-        val d = H264Decoder(surface) { decodedWidth, decodedHeight ->
-            if (isActiveStream(sessionId)) {
-                runOnUiThread {
-                    if (isActiveStream(sessionId)) {
-                        onDecodedSize(decodedWidth, decodedHeight)
+        val d = H264Decoder(
+            surface,
+            onOutputSizeChanged = { decodedWidth, decodedHeight ->
+                if (isActiveStream(sessionId)) {
+                    runOnUiThread {
+                        if (isActiveStream(sessionId)) {
+                            onDecodedSize(decodedWidth, decodedHeight)
+                        }
+                    }
+                }
+            },
+            onFirstFrameRendered = {
+                if (isActiveStream(sessionId)) {
+                    runOnUiThread {
+                        if (isActiveStream(sessionId)) {
+                            onFirstFrameRendered()
+                        }
                     }
                 }
             }
-        }
+        )
         val encrypted = device?.let { it.encrypted && !it.isUsb } == true
         val advertisedFingerprint = device?.fingerprint
         val savedFingerprint = advertisedFingerprint?.takeIf {
@@ -1112,8 +1130,9 @@ fun ReceiveScreen(
     displayHeight: Int,
     status: String,
     onBack: () -> Unit,
-    onSurfaceCreated: (String, Surface, Int, Int) -> Long,
+    onSurfaceCreated: (String, Surface, Int, Int, () -> Unit) -> Long,
     onSurfaceDestroyed: (Long) -> Unit,
+    onSurfaceRenderTimeout: () -> Unit,
     onInputEvent: (android.view.MotionEvent, Float, Float) -> Unit
 ) {
     BackHandler(onBack = onBack)
@@ -1131,6 +1150,7 @@ fun ReceiveScreen(
                 hostIp = hostIp,
                 onSurfaceCreated = onSurfaceCreated,
                 onSurfaceDestroyed = onSurfaceDestroyed,
+                onSurfaceRenderTimeout = onSurfaceRenderTimeout,
                 onInputEvent = onInputEvent
             )
         }
@@ -1158,39 +1178,123 @@ fun StreamSurface(
     width: Int,
     height: Int,
     hostIp: String,
-    onSurfaceCreated: (String, Surface, Int, Int) -> Long,
+    onSurfaceCreated: (String, Surface, Int, Int, () -> Unit) -> Long,
     onSurfaceDestroyed: (Long) -> Unit,
+    onSurfaceRenderTimeout: () -> Unit,
     onInputEvent: (android.view.MotionEvent, Float, Float) -> Unit
 ) {
     AndroidView(
         factory = { ctx ->
-            android.view.SurfaceView(ctx).apply {
+            TextureView(ctx).apply {
                 isClickable = true
-                holder.addCallback(object : SurfaceHolder.Callback {
+                val streamCallback = object : TextureView.SurfaceTextureListener {
                     private var surfaceGeneration = 0L
-                    private var createdSurface: Surface? = null
+                    private var renderSurface: Surface? = null
+                    private var currentSurfaceTexture: SurfaceTexture? = null
+                    private var activeSurfaceWidth = 0
+                    private var activeSurfaceHeight = 0
+                    private var firstFrameRendered = false
+                    private var watchdogRestartUsed = false
 
-                    override fun surfaceCreated(holder: SurfaceHolder) {
-                        createdSurface = holder.surface
+                    override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, w: Int, h: Int) {
+                        currentSurfaceTexture = surfaceTexture
+                        watchdogRestartUsed = false
+                        scheduleSurfaceReadyChecks()
                     }
-                    override fun surfaceChanged(h: SurfaceHolder, f: Int, w: Int, ht: Int) {
-                        if (surfaceGeneration != 0L || w <= 0 || ht <= 0) {
+
+                    override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, w: Int, h: Int) {
+                        currentSurfaceTexture = surfaceTexture
+                        scheduleSurfaceReadyChecks(forceRestart = true)
+                    }
+
+                    override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
+                        stopActiveStream()
+                        currentSurfaceTexture = null
+                        releaseRenderSurface()
+                        return true
+                    }
+
+                    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {
+                        firstFrameRendered = true
+                    }
+
+                    fun scheduleSurfaceReadyChecks(forceRestart: Boolean = false) {
+                        listOf(0L, 50L, 150L, 350L, 700L).forEachIndexed { index, delayMs ->
+                            postDelayed({
+                                maybeStartOrRestartStream(
+                                    this@apply.width,
+                                    this@apply.height,
+                                    forceRestart && index == 0
+                                )
+                            }, delayMs)
+                        }
+                    }
+
+                    private fun maybeStartOrRestartStream(surfaceWidth: Int, surfaceHeight: Int, forceRestart: Boolean) {
+                        val actualWidth = surfaceWidth.takeIf { it > 0 } ?: this@apply.width
+                        val actualHeight = surfaceHeight.takeIf { it > 0 } ?: this@apply.height
+                        if (actualWidth <= 0 || actualHeight <= 0 || !isAttachedToWindow || windowVisibility != android.view.View.VISIBLE) {
                             return
                         }
-                        val surface = createdSurface ?: h.surface
+                        val surfaceTexture = currentSurfaceTexture ?: surfaceTexture ?: return
+                        val surface = renderSurface ?: Surface(surfaceTexture).also {
+                            renderSurface = it
+                        }
                         if (!surface.isValid) {
                             return
                         }
-                        surfaceGeneration = onSurfaceCreated(hostIp, surface, width, height)
+                        if (surfaceGeneration != 0L && !forceRestart) {
+                            if (actualWidth == activeSurfaceWidth && actualHeight == activeSurfaceHeight) {
+                                return
+                            }
+                        }
+                        if (surfaceGeneration != 0L) {
+                            stopActiveStream()
+                        }
+                        activeSurfaceWidth = actualWidth
+                        activeSurfaceHeight = actualHeight
+                        firstFrameRendered = false
+                        surfaceGeneration = onSurfaceCreated(hostIp, surface, width, height) {
+                            firstFrameRendered = true
+                        }
+                        scheduleFirstFrameWatchdog(surfaceGeneration, actualWidth, actualHeight)
                     }
-                    override fun surfaceDestroyed(h: SurfaceHolder) {
+
+                    private fun scheduleFirstFrameWatchdog(generation: Long, surfaceWidth: Int, surfaceHeight: Int) {
+                        postDelayed({
+                            if (generation != surfaceGeneration || firstFrameRendered) {
+                                return@postDelayed
+                            }
+                            if (!watchdogRestartUsed) {
+                                watchdogRestartUsed = true
+                                maybeStartOrRestartStream(surfaceWidth, surfaceHeight, forceRestart = true)
+                            } else {
+                                onSurfaceRenderTimeout()
+                            }
+                        }, 2000L)
+                    }
+
+                    private fun stopActiveStream() {
                         if (surfaceGeneration != 0L) {
                             onSurfaceDestroyed(surfaceGeneration)
                             surfaceGeneration = 0L
                         }
-                        createdSurface = null
+                        activeSurfaceWidth = 0
+                        activeSurfaceHeight = 0
                     }
-                })
+
+                    private fun releaseRenderSurface() {
+                        try {
+                            renderSurface?.release()
+                        } catch (_: Exception) {}
+                        renderSurface = null
+                    }
+                }
+                surfaceTextureListener = streamCallback
+                addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                    streamCallback.scheduleSurfaceReadyChecks()
+                }
+                streamCallback.scheduleSurfaceReadyChecks()
                 fun requestLowLatencyInput(event: android.view.MotionEvent) {
                     when (event.actionMasked) {
                         android.view.MotionEvent.ACTION_DOWN,

--- a/android/app/src/main/java/com/example/monitorize/streaming/H264Decoder.kt
+++ b/android/app/src/main/java/com/example/monitorize/streaming/H264Decoder.kt
@@ -15,7 +15,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class H264Decoder(
     private val surface: Surface,
-    private val onOutputSizeChanged: (Int, Int) -> Unit = { _, _ -> }
+    private val onOutputSizeChanged: (Int, Int) -> Unit = { _, _ -> },
+    private val onFirstFrameRendered: () -> Unit = {}
 ) {
 
     private var codec: MediaCodec? = null
@@ -52,6 +53,7 @@ class H264Decoder(
         release()
         val generation = decoderGeneration.incrementAndGet()
         fatalError.set(false)
+        val firstFrameReported = AtomicBoolean(false)
         try {
             Log.i(TAG, "Init: ${width}×${height}")
 
@@ -140,6 +142,11 @@ class H264Decoder(
                 }, handler)
 
                 it.configure(format, surface, null, 0)
+                it.setOnFrameRenderedListener({ _, _, _ ->
+                    if (isCurrent(generation) && firstFrameReported.compareAndSet(false, true)) {
+                        onFirstFrameRendered()
+                    }
+                }, handler)
                 initialized = true
                 it.start()
             }

--- a/android/app/src/main/java/com/example/monitorize/streaming/StreamReceiver.kt
+++ b/android/app/src/main/java/com/example/monitorize/streaming/StreamReceiver.kt
@@ -162,9 +162,13 @@ class StreamReceiver(
         var writePos = 0
         val readBuf = ByteArray(128 * 1024)
         val accessUnit = ByteArray(MAX_ACCESS_UNIT)
+        val codecConfig = ByteArray(256 * 1024)
         var accessUnitSize = 0
         var accessUnitHasVcl = false
         var accessUnitHasIdr = false
+        var accessUnitHasConfig = false
+        var codecConfigSize = 0
+        var waitingForKeyFrame = true
         var idleReads = 0
         var decoderFailed = false
 
@@ -173,9 +177,28 @@ class StreamReceiver(
                 accessUnitSize = 0
                 accessUnitHasVcl = false
                 accessUnitHasIdr = false
+                accessUnitHasConfig = false
                 return
             }
             if (accessUnitSize > 0 && accessUnitHasVcl) {
+                if (waitingForKeyFrame && !accessUnitHasIdr) {
+                    accessUnitSize = 0
+                    accessUnitHasVcl = false
+                    accessUnitHasIdr = false
+                    accessUnitHasConfig = false
+                    return
+                }
+                if (waitingForKeyFrame && !accessUnitHasConfig && codecConfigSize > 0) {
+                    if (codecConfigSize + accessUnitSize <= accessUnit.size) {
+                        System.arraycopy(accessUnit, 0, accessUnit, codecConfigSize, accessUnitSize)
+                        System.arraycopy(codecConfig, 0, accessUnit, 0, codecConfigSize)
+                        accessUnitSize += codecConfigSize
+                        accessUnitHasConfig = true
+                    } else {
+                        Log.w(TAG, "$streamType codec config too large to prepend, using IDR only")
+                    }
+                }
+                waitingForKeyFrame = false
                 if (!decoder.feedChunk(accessUnit, 0, accessUnitSize, accessUnitHasIdr)) {
                     Log.w(TAG, "$streamType decoder rejected frame; reconnecting")
                     decoderFailed = true
@@ -184,6 +207,21 @@ class StreamReceiver(
             accessUnitSize = 0
             accessUnitHasVcl = false
             accessUnitHasIdr = false
+            accessUnitHasConfig = false
+        }
+
+        fun rememberCodecConfig(nalStart: Int, nalEnd: Int, nalType: Int) {
+            val nalSize = nalEnd - nalStart
+            if (nalSize <= 0 || nalSize > codecConfig.size) return
+            if (nalType == 7) {
+                codecConfigSize = 0
+            }
+            if (codecConfigSize + nalSize > codecConfig.size) {
+                codecConfigSize = 0
+                if (nalSize > codecConfig.size) return
+            }
+            System.arraycopy(buf, nalStart, codecConfig, codecConfigSize, nalSize)
+            codecConfigSize += nalSize
         }
 
         fun appendNalToAccessUnit(nalStart: Int, nalEnd: Int) {
@@ -193,6 +231,10 @@ class StreamReceiver(
             if (nalHeader >= nalEnd) return
 
             val nalType = buf[nalHeader].toInt() and 0x1F
+            val isCodecConfig = nalType == 7 || nalType == 8
+            if (isCodecConfig) {
+                rememberCodecConfig(nalStart, nalEnd, nalType)
+            }
             val isVcl = nalType in 1..5
             val startsNewAccessUnit = accessUnitHasVcl && (
                 nalType in 6..9 ||
@@ -219,6 +261,7 @@ class StreamReceiver(
 
             System.arraycopy(buf, nalStart, accessUnit, accessUnitSize, nalSize)
             accessUnitSize += nalSize
+            if (isCodecConfig) accessUnitHasConfig = true
             if (isVcl) accessUnitHasVcl = true
             if (nalType == 5) accessUnitHasIdr = true
         }

--- a/linux/monitorize/desktop/backend.py
+++ b/linux/monitorize/desktop/backend.py
@@ -269,6 +269,10 @@ class MonitorizeBackend(QObject):
     def stopReceiving(self):
         self.receiver.stop()
 
+    @pyqtSlot("QVariant")
+    def setReceiverVideoItem(self, item):
+        self.receiver.set_video_item(item)
+
     @pyqtSlot(str, str, str, str, str, str, bool)
     def startStreaming(
         self, res, fps, bitrate, display_type, encoder, encoder_profile, wifi

--- a/linux/monitorize/desktop/main_window.py
+++ b/linux/monitorize/desktop/main_window.py
@@ -163,6 +163,8 @@ class MonitorizeWindow(QMainWindow):
 
     def _sync_receiver_fullscreen(self, receiving):
         if receiving:
+            if not self.backend.receiver.should_use_embedded_window():
+                return
             self.receiver_video_window.show_receiver()
             return
         self.receiver_video_window.hide_receiver()

--- a/linux/monitorize/desktop/main_window.py
+++ b/linux/monitorize/desktop/main_window.py
@@ -51,6 +51,9 @@ class MonitorizeWindow(QMainWindow):
         self.de = detect_desktop_environment() or self._ask_desktop_environment()
         self.backend = MonitorizeBackend(self.de, self)
         self.backend.configureDisplayRequested.connect(self._configure_display)
+        self.backend.isReceivingChanged.connect(self._sync_receiver_fullscreen)
+        self.receiver_was_fullscreen = False
+        self.receiver_saved_geometry = None
         self._setup_tray()
         self.quick_widget = QQuickWidget(self)
         self.quick_widget.setResizeMode(
@@ -63,6 +66,19 @@ class MonitorizeWindow(QMainWindow):
         for error in self.quick_widget.errors():
             print(error.toString())
         self.setCentralWidget(self.quick_widget)
+
+    def _sync_receiver_fullscreen(self, receiving):
+        if receiving:
+            self.receiver_was_fullscreen = self.isFullScreen()
+            self.receiver_saved_geometry = self.saveGeometry()
+            self.showFullScreen()
+            return
+        if self.receiver_was_fullscreen:
+            return
+        self.showNormal()
+        if self.receiver_saved_geometry:
+            self.restoreGeometry(self.receiver_saved_geometry)
+        self.receiver_saved_geometry = None
 
     def _setup_tray(self):
         self.tray = QSystemTrayIcon(self)

--- a/linux/monitorize/desktop/main_window.py
+++ b/linux/monitorize/desktop/main_window.py
@@ -54,6 +54,10 @@ class ReceiverVideoWidget(QWidget):
         )
         self.disconnect_button.clicked.connect(self.backend.stopReceiving)
 
+    def sync_video_geometry(self):
+        self.video_surface.setGeometry(self.rect())
+        self.backend.receiver.sync_video_geometry()
+
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Escape:
             self.backend.stopReceiving()
@@ -62,7 +66,7 @@ class ReceiverVideoWidget(QWidget):
         super().keyPressEvent(event)
 
     def resizeEvent(self, event):
-        self.video_surface.setGeometry(self.rect())
+        self.sync_video_geometry()
         margin = 18
         self.disconnect_button.move(
             max(margin, self.width() - self.disconnect_button.width() - margin),
@@ -122,7 +126,7 @@ class MonitorizeWindow(QMainWindow):
             self.content_stack.setCurrentWidget(self.receiver_video_widget)
             self.showFullScreen()
             self.receiver_video_widget.setFocus()
-            self.backend.setReceiverVideoItem(self.receiver_video_widget.video_surface)
+            QTimer.singleShot(50, self._bind_receiver_video_surface)
             return
         self.backend.setReceiverVideoItem(None)
         self.content_stack.setCurrentWidget(self.quick_widget)
@@ -132,6 +136,13 @@ class MonitorizeWindow(QMainWindow):
         if self.receiver_saved_geometry:
             self.restoreGeometry(self.receiver_saved_geometry)
         self.receiver_saved_geometry = None
+
+    def _bind_receiver_video_surface(self):
+        if not self.backend.isReceiving:
+            return
+        self.receiver_video_widget.sync_video_geometry()
+        self.backend.setReceiverVideoItem(self.receiver_video_widget.video_surface)
+        QTimer.singleShot(100, self.receiver_video_widget.sync_video_geometry)
 
     def _setup_tray(self):
         self.tray = QSystemTrayIcon(self)

--- a/linux/monitorize/desktop/main_window.py
+++ b/linux/monitorize/desktop/main_window.py
@@ -18,14 +18,58 @@ from PyQt6.QtWidgets import (
     QMenu,
     QMessageBox,
     QPushButton,
+    QStackedWidget,
     QSystemTrayIcon,
     QVBoxLayout,
+    QWidget,
 )
 
 from monitorize.config import app_log
 from monitorize.desktop.backend import MonitorizeBackend
 from monitorize.platform.process_utils import kill_patterns
 from monitorize.platform.utils import ASSETS_DIR, LINUX_DIR, QML_DIR, detect_desktop_environment
+
+
+class ReceiverVideoWidget(QWidget):
+    def __init__(self, backend, parent=None):
+        super().__init__(parent)
+        self.backend = backend
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.setStyleSheet("background: #000000;")
+        self.video_surface = QWidget(self)
+        self.video_surface.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, True)
+        self.video_surface.setAttribute(
+            Qt.WidgetAttribute.WA_DontCreateNativeAncestors, False
+        )
+        self.video_surface.setStyleSheet("background: #000000;")
+        self.disconnect_button = QPushButton("Disconnect", self)
+        self.disconnect_button.setFixedSize(116, 34)
+        self.disconnect_button.setStyleSheet(
+            "QPushButton {"
+            "background: #991b1b; color: white; border: 0; border-radius: 6px;"
+            "font-size: 12px; font-weight: 700;"
+            "}"
+            "QPushButton:hover { background: #b91c1c; }"
+            "QPushButton:pressed { background: #7f1d1d; }"
+        )
+        self.disconnect_button.clicked.connect(self.backend.stopReceiving)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key.Key_Escape:
+            self.backend.stopReceiving()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def resizeEvent(self, event):
+        self.video_surface.setGeometry(self.rect())
+        margin = 18
+        self.disconnect_button.move(
+            max(margin, self.width() - self.disconnect_button.width() - margin),
+            margin,
+        )
+        self.disconnect_button.raise_()
+        super().resizeEvent(event)
 
 
 class MonitorizeWindow(QMainWindow):
@@ -51,10 +95,10 @@ class MonitorizeWindow(QMainWindow):
         self.de = detect_desktop_environment() or self._ask_desktop_environment()
         self.backend = MonitorizeBackend(self.de, self)
         self.backend.configureDisplayRequested.connect(self._configure_display)
-        self.backend.isReceivingChanged.connect(self._sync_receiver_fullscreen)
         self.receiver_was_fullscreen = False
         self.receiver_saved_geometry = None
         self._setup_tray()
+        self.content_stack = QStackedWidget(self)
         self.quick_widget = QQuickWidget(self)
         self.quick_widget.setResizeMode(
             QQuickWidget.ResizeMode.SizeRootObjectToView
@@ -65,14 +109,23 @@ class MonitorizeWindow(QMainWindow):
         )
         for error in self.quick_widget.errors():
             print(error.toString())
-        self.setCentralWidget(self.quick_widget)
+        self.receiver_video_widget = ReceiverVideoWidget(self.backend, self)
+        self.content_stack.addWidget(self.quick_widget)
+        self.content_stack.addWidget(self.receiver_video_widget)
+        self.setCentralWidget(self.content_stack)
+        self.backend.isReceivingChanged.connect(self._sync_receiver_fullscreen)
 
     def _sync_receiver_fullscreen(self, receiving):
         if receiving:
             self.receiver_was_fullscreen = self.isFullScreen()
             self.receiver_saved_geometry = self.saveGeometry()
+            self.content_stack.setCurrentWidget(self.receiver_video_widget)
             self.showFullScreen()
+            self.receiver_video_widget.setFocus()
+            self.backend.setReceiverVideoItem(self.receiver_video_widget.video_surface)
             return
+        self.backend.setReceiverVideoItem(None)
+        self.content_stack.setCurrentWidget(self.quick_widget)
         if self.receiver_was_fullscreen:
             return
         self.showNormal()

--- a/linux/monitorize/desktop/main_window.py
+++ b/linux/monitorize/desktop/main_window.py
@@ -30,12 +30,18 @@ from monitorize.platform.process_utils import kill_patterns
 from monitorize.platform.utils import ASSETS_DIR, LINUX_DIR, QML_DIR, detect_desktop_environment
 
 
-class ReceiverVideoWidget(QWidget):
+class ReceiverVideoWindow(QWidget):
+    SYNC_DELAYS_MS = (0, 50, 100, 250, 500, 1000)
+
     def __init__(self, backend, parent=None):
-        super().__init__(parent)
+        super().__init__(
+            parent,
+            Qt.WindowType.Window | Qt.WindowType.FramelessWindowHint,
+        )
         self.backend = backend
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.setStyleSheet("background: #000000;")
+        self.setWindowTitle("Monitorize Receiver")
         self.video_surface = QWidget(self)
         self.video_surface.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, True)
         self.video_surface.setAttribute(
@@ -54,9 +60,48 @@ class ReceiverVideoWidget(QWidget):
         )
         self.disconnect_button.clicked.connect(self.backend.stopReceiving)
 
+    def show_receiver(self):
+        self._move_to_parent_screen()
+        self.showFullScreen()
+        self.raise_()
+        self.activateWindow()
+        self.setFocus()
+        self._bind_receiver_video_surface()
+
+    def hide_receiver(self):
+        self.backend.setReceiverVideoItem(None)
+        self.hide()
+
+    def _move_to_parent_screen(self):
+        parent = self.parentWidget()
+        parent_handle = parent.windowHandle() if parent is not None else None
+        screen = parent_handle.screen() if parent_handle is not None else None
+        if screen is None:
+            screen = QApplication.primaryScreen()
+        if screen is not None:
+            self.setGeometry(screen.geometry())
+
     def sync_video_geometry(self):
-        self.video_surface.setGeometry(self.rect())
+        self.video_surface.setGeometry(
+            0, 0, max(1, self.width()), max(1, self.height())
+        )
         self.backend.receiver.sync_video_geometry()
+
+    def _bind_receiver_video_surface(self, attempt=0):
+        if not self.backend.isReceiving or not self.isVisible():
+            return
+        self.sync_video_geometry()
+        if (
+            (self.video_surface.width() <= 1 or self.video_surface.height() <= 1)
+            and attempt < 10
+        ):
+            QTimer.singleShot(
+                50, lambda: self._bind_receiver_video_surface(attempt + 1)
+            )
+            return
+        self.backend.setReceiverVideoItem(self.video_surface)
+        for delay in self.SYNC_DELAYS_MS:
+            QTimer.singleShot(delay, self.sync_video_geometry)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Escape:
@@ -99,8 +144,6 @@ class MonitorizeWindow(QMainWindow):
         self.de = detect_desktop_environment() or self._ask_desktop_environment()
         self.backend = MonitorizeBackend(self.de, self)
         self.backend.configureDisplayRequested.connect(self._configure_display)
-        self.receiver_was_fullscreen = False
-        self.receiver_saved_geometry = None
         self._setup_tray()
         self.content_stack = QStackedWidget(self)
         self.quick_widget = QQuickWidget(self)
@@ -113,36 +156,16 @@ class MonitorizeWindow(QMainWindow):
         )
         for error in self.quick_widget.errors():
             print(error.toString())
-        self.receiver_video_widget = ReceiverVideoWidget(self.backend, self)
         self.content_stack.addWidget(self.quick_widget)
-        self.content_stack.addWidget(self.receiver_video_widget)
         self.setCentralWidget(self.content_stack)
+        self.receiver_video_window = ReceiverVideoWindow(self.backend, self)
         self.backend.isReceivingChanged.connect(self._sync_receiver_fullscreen)
 
     def _sync_receiver_fullscreen(self, receiving):
         if receiving:
-            self.receiver_was_fullscreen = self.isFullScreen()
-            self.receiver_saved_geometry = self.saveGeometry()
-            self.content_stack.setCurrentWidget(self.receiver_video_widget)
-            self.showFullScreen()
-            self.receiver_video_widget.setFocus()
-            QTimer.singleShot(50, self._bind_receiver_video_surface)
+            self.receiver_video_window.show_receiver()
             return
-        self.backend.setReceiverVideoItem(None)
-        self.content_stack.setCurrentWidget(self.quick_widget)
-        if self.receiver_was_fullscreen:
-            return
-        self.showNormal()
-        if self.receiver_saved_geometry:
-            self.restoreGeometry(self.receiver_saved_geometry)
-        self.receiver_saved_geometry = None
-
-    def _bind_receiver_video_surface(self):
-        if not self.backend.isReceiving:
-            return
-        self.receiver_video_widget.sync_video_geometry()
-        self.backend.setReceiverVideoItem(self.receiver_video_widget.video_surface)
-        QTimer.singleShot(100, self.receiver_video_widget.sync_video_geometry)
+        self.receiver_video_window.hide_receiver()
 
     def _setup_tray(self):
         self.tray = QSystemTrayIcon(self)

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -6,7 +6,9 @@ import sys
 import time
 from functools import lru_cache
 
+from PyQt6 import sip
 from PyQt6.QtCore import QObject, QProcess, QTimer, pyqtSignal
+from PyQt6.QtGui import QGuiApplication
 
 from monitorize.platform.process_utils import gst_has_element, kill_patterns, stop_processes
 from monitorize.config.settings import (
@@ -35,8 +37,10 @@ SINK_PROPS = {
     "max-lateness": "20000000",
 }
 SINK_EXTRA_PROPS = {
+    "waylandsink": {"fullscreen": "true"},
     "xvimagesink": {"double-buffer": "true", "draw-borders": "true"},
 }
+EMBEDDED_SINK = "qml6glsink"
 SOFTWARE_DECODER_PROPS = {
     "max-threads": "2",
     "thread-type": "slice",
@@ -44,6 +48,28 @@ SOFTWARE_DECODER_PROPS = {
     "discard-corrupted-frames": "true",
     "automatic-request-sync-points": "true",
 }
+
+_GST = None
+_GST_IMPORT_ERROR = None
+
+
+def _load_gst():
+    global _GST, _GST_IMPORT_ERROR
+    if _GST is not None:
+        return _GST
+    if _GST_IMPORT_ERROR is not None:
+        raise _GST_IMPORT_ERROR
+    try:
+        import gi
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst
+
+        Gst.init(None)
+        _GST = Gst
+        return Gst
+    except Exception as exc:
+        _GST_IMPORT_ERROR = exc
+        raise
 
 
 @lru_cache(maxsize=64)
@@ -112,6 +138,13 @@ class ReceiverController(QObject):
         self.receiver_host = ""
         self.receiver_port = 0
         self.pipeline_fallback_used = False
+        self.stable = False
+        self.video_item = None
+        self.pending_launch = None
+        self.gst_pipeline = None
+        self.gst_bus = None
+        self.gst_generation = None
+        self.embedded_available = None
         self.sink_candidates = []
         self.sink_index = 0
         self.stable_timer = QTimer(self)
@@ -122,6 +155,12 @@ class ReceiverController(QObject):
         self.retry_timer = QTimer(self)
         self.retry_timer.setSingleShot(True)
         self.retry_timer.timeout.connect(lambda: self._start_attempt(self.retry_generation))
+        self.surface_timer = QTimer(self)
+        self.surface_timer.setSingleShot(True)
+        self.surface_timer.timeout.connect(self._surface_wait_expired)
+        self.gst_bus_timer = QTimer(self)
+        self.gst_bus_timer.setInterval(50)
+        self.gst_bus_timer.timeout.connect(self._poll_gst_bus)
 
     def _set_receiving(self, value):
         self.receiving = value
@@ -144,6 +183,7 @@ class ReceiverController(QObject):
         self.generation += 1
         generation = self.generation
         self.stopping = False
+        self.stable = False
         self.host = host
         self.port = port
         self.encrypted = encrypted
@@ -177,9 +217,22 @@ class ReceiverController(QObject):
         self.auth_failed = False
         self.host_label = f"{host}:{port}"
         self.hostChanged.emit(self.host_label)
+        if not encrypted:
+            self._set_receiving(True)
         self._set_status(f"Connecting to {host}:{port}…")
         self.logAppended.emit(f"Connecting to {host} on port {port}…")
         self._start_attempt(generation)
+
+    def set_video_item(self, item):
+        self.video_item = item
+        if item is None:
+            return
+        if self.pending_launch is None:
+            return
+        host, port, generation = self.pending_launch
+        self.pending_launch = None
+        self.surface_timer.stop()
+        self._launch_pipeline(host, port, generation)
 
     def _start_attempt(self, generation=None):
         generation = self.generation if generation is None else generation
@@ -216,6 +269,106 @@ class ReceiverController(QObject):
         generation = self.generation if generation is None else generation
         if self.stopping or generation != self.generation:
             return
+        if self.video_item is not None and self._embedded_sink_available():
+            try:
+                self._launch_embedded_pipeline(host, port, generation)
+                return
+            except Exception as exc:
+                self.logAppended.emit(
+                    f"Embedded receiver failed; falling back to player window: {exc}"
+                )
+                self._stop_gst_pipeline()
+        if self.video_item is None and self._should_wait_for_embedded_surface():
+            self.pending_launch = (host, port, generation)
+            self._set_status("Preparing fullscreen receiver…")
+            self.logAppended.emit("Preparing fullscreen receiver surface…")
+            self.surface_timer.start(1500)
+            return
+        self._launch_external_pipeline(host, port, generation)
+
+    def _surface_wait_expired(self):
+        if self.pending_launch is None:
+            return
+        host, port, generation = self.pending_launch
+        self.pending_launch = None
+        if self.stopping or generation != self.generation:
+            return
+        self.logAppended.emit(
+            "Fullscreen receiver surface was not ready; using fallback player window."
+        )
+        self._launch_external_pipeline(host, port, generation)
+
+    def _embedded_sink_available(self):
+        if self.embedded_available is not None:
+            return self.embedded_available
+        try:
+            Gst = _load_gst()
+            sink = Gst.ElementFactory.make(EMBEDDED_SINK)
+            self.embedded_available = bool(
+                sink is not None and sink.find_property("widget") is not None
+            )
+        except Exception:
+            self.embedded_available = False
+        return self.embedded_available
+
+    def _should_wait_for_embedded_surface(self):
+        app = QGuiApplication.instance()
+        return isinstance(app, QGuiApplication) and self._embedded_sink_available()
+
+    def _launch_embedded_pipeline(self, host, port, generation):
+        self.receiver_host = host
+        self.receiver_port = port
+        self.attempt_started = time.monotonic()
+        self._stop_gst_pipeline()
+        Gst = _load_gst()
+        description = self._embedded_pipeline_description(host, port)
+        pipeline = Gst.parse_launch(description)
+        sink = pipeline.get_by_name("receiver_sink")
+        if sink is None:
+            raise RuntimeError("embedded receiver sink was not created")
+        self._bind_embedded_sink(sink)
+        bus = pipeline.get_bus()
+        result = pipeline.set_state(Gst.State.PLAYING)
+        if result == Gst.StateChangeReturn.FAILURE:
+            pipeline.set_state(Gst.State.NULL)
+            raise RuntimeError("GStreamer refused to start embedded receiver pipeline")
+        self.gst_pipeline = pipeline
+        self.gst_bus = bus
+        self.gst_generation = generation
+        self.gst_bus_timer.start()
+        self.logAppended.emit(f"Decoder: {self.decoder_label}; sink: {EMBEDDED_SINK}")
+        self._started(pipeline, generation)
+
+    def _embedded_pipeline_description(self, host, port):
+        sink_args = self._sink_args(EMBEDDED_SINK)
+        sink_args[0] = f"{EMBEDDED_SINK}"
+        sink_args.append("name=receiver_sink")
+        parts = [
+            "tcpclientsrc", f"host={host}", f"port={port}", "!",
+            "h264parse", "disable-passthrough=true", "config-interval=-1", "!",
+            PARSED_H264_CAPS, "!",
+            *COMPRESSED_QUEUE, "!",
+            *self.decoder_args, "!",
+            *RAW_DROP_QUEUE, "!",
+            "videoconvert", "!",
+            "glupload", "!",
+            "glcolorconvert", "!",
+            *sink_args,
+        ]
+        return " ".join(parts)
+
+    def _bind_embedded_sink(self, sink):
+        if self.video_item is None:
+            raise RuntimeError("receiver video surface is not available")
+        try:
+            sink.set_property("widget", self.video_item)
+        except Exception:
+            sink.set_property("widget", int(sip.unwrapinstance(self.video_item)))
+
+    def _launch_external_pipeline(self, host, port, generation=None):
+        generation = self.generation if generation is None else generation
+        if self.stopping or generation != self.generation:
+            return
         self.receiver_host = host
         self.receiver_port = port
         self.attempt_started = time.monotonic()
@@ -245,10 +398,16 @@ class ReceiverController(QObject):
         self.process.start("gst-launch-1.0", args)
 
     def _sink_candidates(self):
-        candidates = ["glimagesink"]
+        candidates = []
         session = os.environ.get("XDG_SESSION_TYPE", "").lower()
         if session == "wayland" or os.environ.get("WAYLAND_DISPLAY"):
-            candidates.append("waylandsink")
+            if self._prefer_windowless_external_sink():
+                candidates.append("waylandsink")
+            candidates.append("glimagesink")
+            if not self._prefer_windowless_external_sink():
+                candidates.append("waylandsink")
+        else:
+            candidates.append("glimagesink")
         if session == "x11" or os.environ.get("DISPLAY"):
             candidates.extend(["xvimagesink", "ximagesink"])
         candidates.append("autovideosink")
@@ -261,6 +420,10 @@ class ReceiverController(QObject):
             if sink == "autovideosink" or gst_has_element(sink):
                 available.append(sink)
         return available or ["autovideosink"]
+
+    def _prefer_windowless_external_sink(self):
+        app = QGuiApplication.instance()
+        return isinstance(app, QGuiApplication)
 
     def _sink_args(self, sink):
         props = dict(SINK_PROPS)
@@ -292,7 +455,7 @@ class ReceiverController(QObject):
             f"{self.decoder_label}; sink: {self.sink}"
         )
         self.process = None
-        self._launch_pipeline(self.receiver_host, self.receiver_port, self.generation)
+        self._launch_external_pipeline(self.receiver_host, self.receiver_port, self.generation)
         return True
 
     def _started(self, process=None, generation=None):
@@ -309,14 +472,54 @@ class ReceiverController(QObject):
     def _mark_stable(self, generation=None, process=None):
         generation = self.generation if generation is None else generation
         process = self.process if process is None else process
-        if generation != self.generation or process is not self.process:
+        if (
+            generation != self.generation
+            or (process is not self.process and process is not self.gst_pipeline)
+        ):
             return
-        if process and process.state() == QProcess.ProcessState.Running:
+        running = (
+            process and (
+                process is self.gst_pipeline
+                or process.state() == QProcess.ProcessState.Running
+            )
+        )
+        if running:
             self._inhibit_sleep()
             self.retry_count = 0
+            self.stable = True
             self._set_receiving(True)
             self._set_status(f"Receiving from {self.host}:{self.port}")
-            self.logAppended.emit("Stream connected and stable.")
+            self.logAppended.emit("Stream connected in fullscreen receiver.")
+
+    def _poll_gst_bus(self):
+        if self.gst_pipeline is None or self.gst_bus is None:
+            self.gst_bus_timer.stop()
+            return
+        Gst = _load_gst()
+        while True:
+            message = self.gst_bus.pop()
+            if message is None:
+                break
+            generation = self.gst_generation
+            if generation != self.generation:
+                continue
+            if message.type == Gst.MessageType.ERROR:
+                error, debug = message.parse_error()
+                self.logAppended.emit(f"Receiver pipeline error: {error.message}")
+                if debug:
+                    self.logAppended.emit(debug)
+                self._embedded_finished(1, generation)
+                break
+            if message.type == Gst.MessageType.EOS:
+                self._embedded_finished(0, generation)
+                break
+            if message.type == Gst.MessageType.NEW_CLOCK and not self.stable:
+                self._mark_stable(generation, self.gst_pipeline)
+
+    def _embedded_finished(self, code, generation):
+        pipeline = self.gst_pipeline
+        self._finished(code, None, pipeline, generation)
+        self._stop_gst_pipeline()
 
     def _read_tls(self, process=None, generation=None):
         process = self.tls_process if process is None else process
@@ -331,6 +534,7 @@ class ReceiverController(QObject):
         self.tls_buffer = lines.pop() if not self.tls_buffer.endswith("\n") else ""
         for line in lines:
             if line == "[TLS RECEIVER] READY" and self.process is None:
+                self._set_receiving(True)
                 self._launch_pipeline("127.0.0.1", 17110, generation)
             elif line.startswith("[TLS RECEIVER] CREDENTIALS "):
                 fingerprint, token = line.removeprefix(
@@ -380,7 +584,10 @@ class ReceiverController(QObject):
     def _finished(self, code, _status, process=None, generation=None):
         process = self.process if process is None else process
         generation = self.generation if generation is None else generation
-        if generation != self.generation or process is not self.process:
+        if (
+            generation != self.generation
+            or (process is not self.process and process is not self.gst_pipeline)
+        ):
             return
         self.logAppended.emit(f"Receiver process exited (code {code})")
         self.stable_timer.stop()
@@ -388,15 +595,15 @@ class ReceiverController(QObject):
         if (
             code
             and not self.stopping
-            and not self.receiving
+            and not self.stable
             and elapsed < 2
             and self._use_receiver_fallback()
         ):
             return
-        max_retries = 30 if self.receiving else 10
+        max_retries = 30 if self.stable else 10
         if (
             not self.stopping
-            and (self.receiving or elapsed < 2)
+            and (self.stable or elapsed < 2)
             and self.retry_count < max_retries - 1
         ):
             self.retry_count += 1
@@ -411,17 +618,22 @@ class ReceiverController(QObject):
             self.retry_generation = generation
             self.retry_timer.start(1000)
             return
-        if self.receiving:
+        if self.stable:
             self._set_status("Disconnected")
             self.logAppended.emit("Stream ended. Click Disconnect to return.")
         else:
             self._set_status("Unable to start stream after 10 attempts")
+            self._set_receiving(False)
 
     def stop(self):
         self.generation += 1
         self.stopping = True
+        self.stable = False
         self.stable_timer.stop()
         self.retry_timer.stop()
+        self.surface_timer.stop()
+        self.pending_launch = None
+        self._stop_gst_pipeline()
         stop_processes(self.process, self.tls_process)
         self.process = self.tls_process = None
         self.tls_buffer = ""
@@ -431,6 +643,20 @@ class ReceiverController(QObject):
         kill_patterns("gst-launch-1.0.*tcpclientsrc")
         self._uninhibit_sleep()
         self._set_receiving(False)
+
+    def _stop_gst_pipeline(self):
+        self.gst_bus_timer.stop()
+        pipeline = self.gst_pipeline
+        self.gst_pipeline = None
+        self.gst_bus = None
+        self.gst_generation = None
+        if pipeline is None:
+            return
+        try:
+            Gst = _load_gst()
+            pipeline.set_state(Gst.State.NULL)
+        except Exception:
+            pass
 
     def _inhibit_sleep(self):
         try:

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -307,7 +307,7 @@ class ReceiverController(QObject):
         generation = self.generation if generation is None else generation
         if self.stopping or generation != self.generation:
             return
-        if self.video_item is not None and self._embedded_sink_available():
+        if self.video_item is not None and self.should_use_embedded_window():
             if not self._update_receiver_surface_size():
                 self.pending_launch = (host, port, generation)
                 self._set_status("Preparing fullscreen receiver…")
@@ -364,7 +364,17 @@ class ReceiverController(QObject):
 
     def _should_wait_for_embedded_surface(self):
         app = QGuiApplication.instance()
-        return isinstance(app, QGuiApplication) and self._embedded_sink_available()
+        return isinstance(app, QGuiApplication) and self.should_use_embedded_window()
+
+    def should_use_embedded_window(self):
+        override = os.environ.get("MONITORIZE_RECEIVER_EMBEDDED", "").strip().lower()
+        if override in {"1", "true", "yes", "on"}:
+            return self._embedded_sink_available()
+        session = os.environ.get("XDG_SESSION_TYPE", "").lower()
+        wayland = session == "wayland" or bool(os.environ.get("WAYLAND_DISPLAY"))
+        if wayland:
+            return False
+        return self._embedded_sink_available()
 
     def _launch_embedded_pipeline(self, host, port, generation):
         self.receiver_host = host
@@ -542,6 +552,11 @@ class ReceiverController(QObject):
             *RAW_DROP_QUEUE, "!",
             *self._sink_args(self.sink),
         ]
+        if self.video_item is not None and not self.should_use_embedded_window():
+            self.logAppended.emit(
+                "Using external fullscreen receiver sink on Wayland; "
+                "embedded receiver can render tiny or crash there."
+            )
         self.logAppended.emit(f"Decoder: {self.decoder_label}; sink: {self.sink}")
         self.process.start("gst-launch-1.0", args)
 

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -148,6 +148,7 @@ class ReceiverController(QObject):
         self.gst_pipeline = None
         self.gst_bus = None
         self.gst_generation = None
+        self.gst_video_sink = None
         self.embedded_sink = None
         self.sink_candidates = []
         self.sink_index = 0
@@ -230,7 +231,9 @@ class ReceiverController(QObject):
     def set_video_item(self, item):
         self.video_item = item
         if item is None:
+            self.gst_video_sink = None
             return
+        self.sync_video_geometry()
         if self.pending_launch is None:
             return
         host, port, generation = self.pending_launch
@@ -341,6 +344,7 @@ class ReceiverController(QObject):
         if sink is None:
             raise RuntimeError("embedded receiver sink was not created")
         self._bind_embedded_sink(sink)
+        self.gst_video_sink = sink
         bus = pipeline.get_bus()
         result = pipeline.set_state(Gst.State.PLAYING)
         if result == Gst.StateChangeReturn.FAILURE:
@@ -377,6 +381,18 @@ class ReceiverController(QObject):
         sink.set_window_handle(handle)
         if hasattr(sink, "handle_events"):
             sink.handle_events(True)
+        self._sync_embedded_sink_geometry(sink)
+
+    def sync_video_geometry(self):
+        self._sync_embedded_sink_geometry(self.gst_video_sink)
+
+    def _sync_embedded_sink_geometry(self, sink):
+        if sink is None or self.video_item is None:
+            return
+        width = max(1, int(self.video_item.width()))
+        height = max(1, int(self.video_item.height()))
+        if hasattr(sink, "set_render_rectangle"):
+            sink.set_render_rectangle(0, 0, width, height)
         if hasattr(sink, "expose"):
             sink.expose()
 
@@ -666,6 +682,7 @@ class ReceiverController(QObject):
         self.gst_pipeline = None
         self.gst_bus = None
         self.gst_generation = None
+        self.gst_video_sink = None
         if pipeline is None:
             return
         try:

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -149,6 +149,7 @@ class ReceiverController(QObject):
         self.gst_bus = None
         self.gst_generation = None
         self.gst_video_sink = None
+        self.bad_geometry_logged = False
         self.embedded_sink = None
         self.sink_candidates = []
         self.sink_index = 0
@@ -334,6 +335,7 @@ class ReceiverController(QObject):
         self.receiver_port = port
         self.attempt_started = time.monotonic()
         self._stop_gst_pipeline()
+        self.bad_geometry_logged = False
         Gst = _load_gst()
         sink_name = self._embedded_sink_name()
         if not sink_name:
@@ -391,6 +393,11 @@ class ReceiverController(QObject):
             return
         width = max(1, int(self.video_item.width()))
         height = max(1, int(self.video_item.height()))
+        if (width <= 64 or height <= 64) and not self.bad_geometry_logged:
+            self.bad_geometry_logged = True
+            self.logAppended.emit(
+                f"Receiver video surface is not fullscreen-sized yet: {width}x{height}"
+            )
         if hasattr(sink, "set_render_rectangle"):
             sink.set_render_rectangle(0, 0, width, height)
         if hasattr(sink, "expose"):

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -27,6 +27,8 @@ RAW_DROP_QUEUE = [
     "leaky=downstream",
 ]
 PARSED_H264_CAPS = "video/x-h264,stream-format=byte-stream,alignment=au"
+MIN_EMBEDDED_SURFACE_SIZE = 128
+RESIZE_RESTART_THRESHOLD = 64
 SINK_PROPS = {
     "sync": "false",
     "async": "false",
@@ -150,6 +152,10 @@ class ReceiverController(QObject):
         self.gst_generation = None
         self.gst_video_sink = None
         self.bad_geometry_logged = False
+        self.receiver_surface_width = 0
+        self.receiver_surface_height = 0
+        self.embedded_pipeline_size = None
+        self.resize_restart_used = False
         self.embedded_sink = None
         self.sink_candidates = []
         self.sink_index = 0
@@ -167,6 +173,11 @@ class ReceiverController(QObject):
         self.gst_bus_timer = QTimer(self)
         self.gst_bus_timer.setInterval(50)
         self.gst_bus_timer.timeout.connect(self._poll_gst_bus)
+        self.resize_restart_timer = QTimer(self)
+        self.resize_restart_timer.setSingleShot(True)
+        self.resize_restart_timer.timeout.connect(
+            lambda: self._restart_embedded_for_resize(self.generation)
+        )
 
     def _set_receiving(self, value):
         self.receiving = value
@@ -221,6 +232,7 @@ class ReceiverController(QObject):
         self.retry_count = 0
         self.retry_pending = False
         self.auth_failed = False
+        self.resize_restart_used = False
         self.host_label = f"{host}:{port}"
         self.hostChanged.emit(self.host_label)
         if not encrypted:
@@ -233,14 +245,32 @@ class ReceiverController(QObject):
         self.video_item = item
         if item is None:
             self.gst_video_sink = None
+            self.receiver_surface_width = 0
+            self.receiver_surface_height = 0
+            self.resize_restart_timer.stop()
             return
+        ready = self._update_receiver_surface_size()
         self.sync_video_geometry()
         if self.pending_launch is None:
             return
+        if ready and self._launch_pending_if_surface_ready():
+            return
+        if not self.surface_timer.isActive():
+            self.surface_timer.start(1500)
+
+    def _launch_pending_if_surface_ready(self):
+        if self.pending_launch is None or not self._receiver_surface_ready():
+            return False
         host, port, generation = self.pending_launch
         self.pending_launch = None
         self.surface_timer.stop()
         self._launch_pipeline(host, port, generation)
+        return True
+
+    def _wait_for_pending_surface_size(self):
+        if self.pending_launch is not None:
+            if not self.surface_timer.isActive():
+                self.surface_timer.start(1500)
 
     def _start_attempt(self, generation=None):
         generation = self.generation if generation is None else generation
@@ -278,6 +308,12 @@ class ReceiverController(QObject):
         if self.stopping or generation != self.generation:
             return
         if self.video_item is not None and self._embedded_sink_available():
+            if not self._update_receiver_surface_size():
+                self.pending_launch = (host, port, generation)
+                self._set_status("Preparing fullscreen receiver…")
+                self.logAppended.emit("Waiting for fullscreen receiver surface size…")
+                self.surface_timer.start(1500)
+                return
             try:
                 self._launch_embedded_pipeline(host, port, generation)
                 return
@@ -355,8 +391,15 @@ class ReceiverController(QObject):
         self.gst_pipeline = pipeline
         self.gst_bus = bus
         self.gst_generation = generation
+        self.embedded_pipeline_size = (
+            self.receiver_surface_width,
+            self.receiver_surface_height,
+        )
         self.gst_bus_timer.start()
-        self.logAppended.emit(f"Decoder: {self.decoder_label}; embedded sink: {sink_name}")
+        self.logAppended.emit(
+            f"Decoder: {self.decoder_label}; embedded sink: {sink_name}; "
+            f"scaled to {self.receiver_surface_width}x{self.receiver_surface_height}"
+        )
         self._started(pipeline, generation)
 
     def _embedded_pipeline_description(self, host, port, sink_name=None):
@@ -364,6 +407,7 @@ class ReceiverController(QObject):
         sink_args = self._sink_args(sink_name, include_extra=False)
         sink_args[0] = sink_name
         sink_args.append("name=receiver_sink")
+        width, height = self._receiver_surface_size()
         parts = [
             "tcpclientsrc", f"host={host}", f"port={port}", "!",
             "h264parse", "disable-passthrough=true", "config-interval=-1", "!",
@@ -371,6 +415,9 @@ class ReceiverController(QObject):
             *COMPRESSED_QUEUE, "!",
             *self.decoder_args, "!",
             *RAW_DROP_QUEUE, "!",
+            "videoconvert", "!",
+            "videoscale", "add-borders=false", "!",
+            f"video/x-raw,width={width},height={height},pixel-aspect-ratio=1/1", "!",
             "videoconvert", "!",
             *sink_args,
         ]
@@ -386,13 +433,17 @@ class ReceiverController(QObject):
         self._sync_embedded_sink_geometry(sink)
 
     def sync_video_geometry(self):
+        self._update_receiver_surface_size()
         self._sync_embedded_sink_geometry(self.gst_video_sink)
+        self._schedule_embedded_resize_restart()
+        if not self._launch_pending_if_surface_ready():
+            self._wait_for_pending_surface_size()
 
     def _sync_embedded_sink_geometry(self, sink):
         if sink is None or self.video_item is None:
             return
-        width = max(1, int(self.video_item.width()))
-        height = max(1, int(self.video_item.height()))
+        self._update_receiver_surface_size()
+        width, height = self._receiver_surface_size()
         if (width <= 64 or height <= 64) and not self.bad_geometry_logged:
             self.bad_geometry_logged = True
             self.logAppended.emit(
@@ -402,6 +453,65 @@ class ReceiverController(QObject):
             sink.set_render_rectangle(0, 0, width, height)
         if hasattr(sink, "expose"):
             sink.expose()
+
+    def _receiver_surface_size(self):
+        return (
+            max(1, int(self.receiver_surface_width)),
+            max(1, int(self.receiver_surface_height)),
+        )
+
+    def _update_receiver_surface_size(self):
+        if self.video_item is None:
+            return False
+        try:
+            width = max(1, int(self.video_item.width()))
+            height = max(1, int(self.video_item.height()))
+        except (TypeError, ValueError):
+            width = height = 0
+        self.receiver_surface_width = width
+        self.receiver_surface_height = height
+        return self._receiver_surface_ready(width, height)
+
+    def _receiver_surface_ready(self, width=None, height=None):
+        width = self.receiver_surface_width if width is None else width
+        height = self.receiver_surface_height if height is None else height
+        return width >= MIN_EMBEDDED_SURFACE_SIZE and height >= MIN_EMBEDDED_SURFACE_SIZE
+
+    def _schedule_embedded_resize_restart(self):
+        if (
+            self.gst_pipeline is None
+            or self.video_item is None
+            or self.embedded_pipeline_size is None
+            or self.resize_restart_used
+            or self.stopping
+            or not self._receiver_surface_ready()
+        ):
+            return
+        width, height = self._receiver_surface_size()
+        old_width, old_height = self.embedded_pipeline_size
+        changed = (
+            abs(width - old_width) >= RESIZE_RESTART_THRESHOLD
+            or abs(height - old_height) >= RESIZE_RESTART_THRESHOLD
+        )
+        if changed and not self.resize_restart_timer.isActive():
+            self.resize_restart_timer.start(150)
+
+    def _restart_embedded_for_resize(self, generation=None):
+        generation = self.generation if generation is None else generation
+        if (
+            generation != self.generation
+            or self.stopping
+            or self.gst_pipeline is None
+            or self.video_item is None
+            or self.resize_restart_used
+            or not self._receiver_surface_ready()
+        ):
+            return
+        self.resize_restart_used = True
+        self.logAppended.emit(
+            "Receiver surface size changed; restarting embedded receiver pipeline."
+        )
+        self._launch_embedded_pipeline(self.receiver_host, self.receiver_port, generation)
 
     def _launch_external_pipeline(self, host, port, generation=None):
         generation = self.generation if generation is None else generation
@@ -678,6 +788,9 @@ class ReceiverController(QObject):
         self.tls_buffer = ""
         self.auth_failed = self.retry_pending = False
         self.pipeline_fallback_used = False
+        self.resize_restart_used = False
+        self.receiver_surface_width = self.receiver_surface_height = 0
+        self.embedded_pipeline_size = None
         self.stable_generation = self.stable_process = self.retry_generation = None
         kill_patterns("gst-launch-1.0.*tcpclientsrc")
         self._uninhibit_sleep()
@@ -690,6 +803,7 @@ class ReceiverController(QObject):
         self.gst_bus = None
         self.gst_generation = None
         self.gst_video_sink = None
+        self.embedded_pipeline_size = None
         if pipeline is None:
             return
         try:

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -39,7 +39,8 @@ SINK_EXTRA_PROPS = {
     "waylandsink": {"fullscreen": "true"},
     "xvimagesink": {"double-buffer": "true", "draw-borders": "true"},
 }
-EMBEDDED_SINKS = ("glimagesink", "xvimagesink", "ximagesink")
+EMBEDDED_X11_SINKS = ("xvimagesink", "ximagesink", "glimagesink")
+EMBEDDED_WAYLAND_SINKS = ("waylandsink", "glimagesink")
 SOFTWARE_DECODER_PROPS = {
     "max-threads": "2",
     "thread-type": "slice",
@@ -307,11 +308,19 @@ class ReceiverController(QObject):
     def _embedded_sink_name(self):
         if self.embedded_sink:
             return self.embedded_sink
-        for name in EMBEDDED_SINKS:
+        for name in self._embedded_sink_candidates():
             if gst_has_element(name):
                 self.embedded_sink = name
                 return name
         return None
+
+    def _embedded_sink_candidates(self):
+        session = os.environ.get("XDG_SESSION_TYPE", "").lower()
+        if session == "wayland" or os.environ.get("WAYLAND_DISPLAY"):
+            return EMBEDDED_WAYLAND_SINKS
+        if session == "x11" or os.environ.get("DISPLAY"):
+            return EMBEDDED_X11_SINKS
+        return ("glimagesink",)
 
     def _should_wait_for_embedded_surface(self):
         app = QGuiApplication.instance()
@@ -346,7 +355,7 @@ class ReceiverController(QObject):
 
     def _embedded_pipeline_description(self, host, port, sink_name=None):
         sink_name = sink_name or self._embedded_sink_name() or "glimagesink"
-        sink_args = self._sink_args(sink_name)
+        sink_args = self._sink_args(sink_name, include_extra=False)
         sink_args[0] = sink_name
         sink_args.append("name=receiver_sink")
         parts = [
@@ -368,6 +377,8 @@ class ReceiverController(QObject):
         sink.set_window_handle(handle)
         if hasattr(sink, "handle_events"):
             sink.handle_events(True)
+        if hasattr(sink, "expose"):
+            sink.expose()
 
     def _launch_external_pipeline(self, host, port, generation=None):
         generation = self.generation if generation is None else generation
@@ -429,9 +440,10 @@ class ReceiverController(QObject):
         app = QGuiApplication.instance()
         return isinstance(app, QGuiApplication)
 
-    def _sink_args(self, sink):
+    def _sink_args(self, sink, include_extra=True):
         props = dict(SINK_PROPS)
-        props.update(SINK_EXTRA_PROPS.get(sink, {}))
+        if include_extra:
+            props.update(SINK_EXTRA_PROPS.get(sink, {}))
         args = [sink]
         for name, value in props.items():
             if _gst_has_property(sink, name):

--- a/linux/monitorize/desktop/receiver_controller.py
+++ b/linux/monitorize/desktop/receiver_controller.py
@@ -6,7 +6,6 @@ import sys
 import time
 from functools import lru_cache
 
-from PyQt6 import sip
 from PyQt6.QtCore import QObject, QProcess, QTimer, pyqtSignal
 from PyQt6.QtGui import QGuiApplication
 
@@ -40,7 +39,7 @@ SINK_EXTRA_PROPS = {
     "waylandsink": {"fullscreen": "true"},
     "xvimagesink": {"double-buffer": "true", "draw-borders": "true"},
 }
-EMBEDDED_SINK = "qml6glsink"
+EMBEDDED_SINKS = ("glimagesink", "xvimagesink", "ximagesink")
 SOFTWARE_DECODER_PROPS = {
     "max-threads": "2",
     "thread-type": "slice",
@@ -50,11 +49,12 @@ SOFTWARE_DECODER_PROPS = {
 }
 
 _GST = None
+_GST_VIDEO = None
 _GST_IMPORT_ERROR = None
 
 
 def _load_gst():
-    global _GST, _GST_IMPORT_ERROR
+    global _GST, _GST_VIDEO, _GST_IMPORT_ERROR
     if _GST is not None:
         return _GST
     if _GST_IMPORT_ERROR is not None:
@@ -62,10 +62,13 @@ def _load_gst():
     try:
         import gi
         gi.require_version("Gst", "1.0")
+        gi.require_version("GstVideo", "1.0")
         from gi.repository import Gst
+        from gi.repository import GstVideo
 
         Gst.init(None)
         _GST = Gst
+        _GST_VIDEO = GstVideo
         return Gst
     except Exception as exc:
         _GST_IMPORT_ERROR = exc
@@ -144,7 +147,7 @@ class ReceiverController(QObject):
         self.gst_pipeline = None
         self.gst_bus = None
         self.gst_generation = None
-        self.embedded_available = None
+        self.embedded_sink = None
         self.sink_candidates = []
         self.sink_index = 0
         self.stable_timer = QTimer(self)
@@ -299,17 +302,16 @@ class ReceiverController(QObject):
         self._launch_external_pipeline(host, port, generation)
 
     def _embedded_sink_available(self):
-        if self.embedded_available is not None:
-            return self.embedded_available
-        try:
-            Gst = _load_gst()
-            sink = Gst.ElementFactory.make(EMBEDDED_SINK)
-            self.embedded_available = bool(
-                sink is not None and sink.find_property("widget") is not None
-            )
-        except Exception:
-            self.embedded_available = False
-        return self.embedded_available
+        return self._embedded_sink_name() is not None
+
+    def _embedded_sink_name(self):
+        if self.embedded_sink:
+            return self.embedded_sink
+        for name in EMBEDDED_SINKS:
+            if gst_has_element(name):
+                self.embedded_sink = name
+                return name
+        return None
 
     def _should_wait_for_embedded_surface(self):
         app = QGuiApplication.instance()
@@ -321,7 +323,10 @@ class ReceiverController(QObject):
         self.attempt_started = time.monotonic()
         self._stop_gst_pipeline()
         Gst = _load_gst()
-        description = self._embedded_pipeline_description(host, port)
+        sink_name = self._embedded_sink_name()
+        if not sink_name:
+            raise RuntimeError("no embeddable GStreamer video sink is available")
+        description = self._embedded_pipeline_description(host, port, sink_name)
         pipeline = Gst.parse_launch(description)
         sink = pipeline.get_by_name("receiver_sink")
         if sink is None:
@@ -336,12 +341,13 @@ class ReceiverController(QObject):
         self.gst_bus = bus
         self.gst_generation = generation
         self.gst_bus_timer.start()
-        self.logAppended.emit(f"Decoder: {self.decoder_label}; sink: {EMBEDDED_SINK}")
+        self.logAppended.emit(f"Decoder: {self.decoder_label}; embedded sink: {sink_name}")
         self._started(pipeline, generation)
 
-    def _embedded_pipeline_description(self, host, port):
-        sink_args = self._sink_args(EMBEDDED_SINK)
-        sink_args[0] = f"{EMBEDDED_SINK}"
+    def _embedded_pipeline_description(self, host, port, sink_name=None):
+        sink_name = sink_name or self._embedded_sink_name() or "glimagesink"
+        sink_args = self._sink_args(sink_name)
+        sink_args[0] = sink_name
         sink_args.append("name=receiver_sink")
         parts = [
             "tcpclientsrc", f"host={host}", f"port={port}", "!",
@@ -351,8 +357,6 @@ class ReceiverController(QObject):
             *self.decoder_args, "!",
             *RAW_DROP_QUEUE, "!",
             "videoconvert", "!",
-            "glupload", "!",
-            "glcolorconvert", "!",
             *sink_args,
         ]
         return " ".join(parts)
@@ -360,10 +364,10 @@ class ReceiverController(QObject):
     def _bind_embedded_sink(self, sink):
         if self.video_item is None:
             raise RuntimeError("receiver video surface is not available")
-        try:
-            sink.set_property("widget", self.video_item)
-        except Exception:
-            sink.set_property("widget", int(sip.unwrapinstance(self.video_item)))
+        handle = int(self.video_item.winId())
+        sink.set_window_handle(handle)
+        if hasattr(sink, "handle_events"):
+            sink.handle_events(True)
 
     def _launch_external_pipeline(self, host, port, generation=None):
         generation = self.generation if generation is None else generation

--- a/linux/monitorize/qml/ReceiverStreamingPage.qml
+++ b/linux/monitorize/qml/ReceiverStreamingPage.qml
@@ -7,6 +7,16 @@ Item {
 
     property var allLogs: []
 
+    focus: true
+    Keys.onEscapePressed: backend.stopReceiving()
+
+    Component.onCompleted: {
+        forceActiveFocus()
+        videoHost.createVideoItem()
+    }
+
+    Component.onDestruction: backend.setReceiverVideoItem(null)
+
     Connections {
         target: backend
         function onReceiverLogAppended(msg) {
@@ -16,176 +26,121 @@ Item {
 
     function appendLog(msg) {
         allLogs.push(msg)
-        updateLogDisplay()
-    }
-
-    function updateLogDisplay() {
-        let text = ""
-        for (let i = 0; i < allLogs.length; i++) {
-            let logMsg = allLogs[i]
-            let msgColor = "#e2e8f0"
-            let lowerMsg = logMsg.toLowerCase()
-            if (lowerMsg.includes("error") || lowerMsg.includes("failed")) {
-                msgColor = "#fca5a5"
-            } else if (lowerMsg.includes("connected") || lowerMsg.includes("playing") || lowerMsg.includes("receiving")) {
-                msgColor = "#86efac"
-            } else if (lowerMsg.includes("connecting") || lowerMsg.includes("waiting")) {
-                msgColor = "#fde047"
-            }
-            text += "<b><font color='#60a5fa'>[RECEIVER]</font></b> &nbsp;<font color='" + msgColor + "'>" + logMsg + "</font><br>"
+        if (allLogs.length > 8) {
+            allLogs.shift()
         }
-        logArea.text = text
-        logScrollView.contentItem.contentY = Math.max(0, logArea.implicitHeight - logScrollView.height)
+        logArea.text = allLogs.join("\n")
     }
 
-    ColumnLayout {
+    Rectangle {
         anchors.fill: parent
-        spacing: 14
+        color: "#000000"
+    }
 
-        // Top Status Card
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: 60
-            radius: theme.cardRadius
-            color: theme.surface
-            border.color: theme.border
-            border.width: 1
+    HoverHandler {
+        id: overlayHover
+    }
 
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 20
-                anchors.rightMargin: 20
-                spacing: 20
+    Item {
+        id: videoHost
+        anchors.fill: parent
+        property var videoItem: null
 
-                // Pulsing Active Indicator
-                Rectangle {
-                    width: 12
-                    height: 12
-                    radius: 6
-                    color: theme.accent
-
-                    SequentialAnimation on opacity {
-                        running: backend.isReceiving
-                        loops: Animation.Infinite
-                        NumberAnimation { from: 0.3; to: 1.0; duration: 800 }
-                        NumberAnimation { from: 1.0; to: 0.3; duration: 800 }
-                    }
-                }
-
-                Text {
-                    text: "Receiving Stream"
-                    font.pixelSize: 18
-                    font.weight: Font.Bold
-                    color: theme.accent
-                }
-
-                Text {
-                    text: backend.receiverStatus
-                    font.pixelSize: 13
-                    color: theme.cardTextSecondary
-                    Layout.fillWidth: true
-                }
+        function createVideoItem() {
+            if (videoItem !== null) {
+                backend.setReceiverVideoItem(videoItem)
+                return
+            }
+            try {
+                videoItem = Qt.createQmlObject(
+                    "import QtQuick\n" +
+                    "import org.freedesktop.gstreamer.Qt6GLVideoItem 1.0\n" +
+                    "GstGLQt6VideoItem {" +
+                    "    objectName: \"receiverVideoItem\";" +
+                    "    anchors.fill: parent;" +
+                    "    forceAspectRatio: false;" +
+                    "    acceptEvents: false" +
+                    "}",
+                    videoHost,
+                    "receiverVideoItem"
+                )
+                backend.setReceiverVideoItem(videoItem)
+            } catch (err) {
+                backend.setReceiverVideoItem(null)
+                page.appendLog("Embedded video unavailable; using fallback player window.")
+                page.appendLog(String(err))
             }
         }
+    }
 
-        // Info card
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: infoCol.implicitHeight + 20
-            radius: 8
-            color: theme.surfaceAlt
-            border.color: theme.border
-            border.width: 1
+    Rectangle {
+        id: topBar
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: 56
+        color: "#aa000000"
+        visible: overlayHover.hovered || backend.receiverStatus.indexOf("Receiving from") !== 0
 
-            ColumnLayout {
-                id: infoCol
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins: 16
-                spacing: 6
-
-                Text {
-                    text: "Connected to: " + backend.receiverHostIp
-                    font.pixelSize: 14
-                    font.weight: Font.Bold
-                    color: theme.cardTextPrimary
-                }
-                Text {
-                    text: "The GStreamer player window should appear. Press Esc in that window to close it."
-                    font.pixelSize: 12
-                    color: theme.cardTextMuted
-                    wrapMode: Text.Wrap
-                    Layout.fillWidth: true
-                }
-            }
-        }
-
-        // Log Box Container
-        Rectangle {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            color: theme.logBoxBackground
-            border.color: theme.border
-            border.width: 1
-            radius: 8
-
-            ScrollView {
-                id: logScrollView
-                anchors.fill: parent
-                anchors.margins: 10
-                clip: true
-
-                TextEdit {
-                    id: logArea
-                    textFormat: Text.RichText
-                    font.family: "Fira Code, JetBrains Mono, DejaVu Sans Mono, Consolas, monospace"
-                    font.pixelSize: 12
-                    color: theme.cardTextPrimary
-                    readOnly: true
-                    selectByMouse: true
-                    wrapMode: TextEdit.WrapAnywhere
-                    leftPadding: 8
-                    rightPadding: 8
-                    topPadding: 8
-                    bottomPadding: 8
-
-                    onImplicitHeightChanged: {
-                        logScrollView.contentItem.contentY = Math.max(0, implicitHeight - logScrollView.height)
-                    }
-
-                }
-            }
-        }
-
-        // Bottom control
         RowLayout {
-            spacing: 12
-            Layout.alignment: Qt.AlignLeft
-            Layout.bottomMargin: 10
+            anchors.fill: parent
+            anchors.leftMargin: 18
+            anchors.rightMargin: 18
+            spacing: 14
+
+            Rectangle {
+                width: 10
+                height: 10
+                radius: 5
+                color: backend.receiverStatus.indexOf("Receiving from") === 0 ? "#22c55e" : "#facc15"
+            }
+
+            Text {
+                text: backend.receiverStatus
+                color: "#f8fafc"
+                font.pixelSize: 13
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
 
             Button {
-                text: "⏹ Disconnect"
-                onClicked: {
-                    allLogs = []
-                    backend.stopReceiving()
-                }
+                text: "Disconnect"
+                onClicked: backend.stopReceiving()
                 background: Rectangle {
-                    implicitWidth: 150
-                    implicitHeight: 38
-                    color: parent.down ? "#5a1010" : (parent.hovered ? "#c42830" : "#a82028")
-                    radius: 8
-                    Behavior on color { ColorAnimation { duration: 150 } }
+                    implicitWidth: 116
+                    implicitHeight: 34
+                    color: parent.down ? "#7f1d1d" : (parent.hovered ? "#b91c1c" : "#991b1b")
+                    radius: 6
                 }
                 contentItem: Text {
                     text: parent.text
                     color: "#ffffff"
-                    font.pixelSize: 13
+                    font.pixelSize: 12
                     font.weight: Font.Bold
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                 }
             }
+        }
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: logArea.text.length > 0 && overlayHover.hovered ? 96 : 0
+        color: "#aa000000"
+        clip: true
+
+        Text {
+            id: logArea
+            anchors.fill: parent
+            anchors.margins: 12
+            color: "#cbd5e1"
+            font.family: "Fira Code, JetBrains Mono, DejaVu Sans Mono, Consolas, monospace"
+            font.pixelSize: 11
+            elide: Text.ElideRight
+            wrapMode: Text.WrapAnywhere
         }
     }
 }

--- a/linux/monitorize/qml/ReceiverStreamingPage.qml
+++ b/linux/monitorize/qml/ReceiverStreamingPage.qml
@@ -12,10 +12,7 @@ Item {
 
     Component.onCompleted: {
         forceActiveFocus()
-        videoHost.createVideoItem()
     }
-
-    Component.onDestruction: backend.setReceiverVideoItem(null)
 
     Connections {
         target: backend
@@ -39,38 +36,6 @@ Item {
 
     HoverHandler {
         id: overlayHover
-    }
-
-    Item {
-        id: videoHost
-        anchors.fill: parent
-        property var videoItem: null
-
-        function createVideoItem() {
-            if (videoItem !== null) {
-                backend.setReceiverVideoItem(videoItem)
-                return
-            }
-            try {
-                videoItem = Qt.createQmlObject(
-                    "import QtQuick\n" +
-                    "import org.freedesktop.gstreamer.Qt6GLVideoItem 1.0\n" +
-                    "GstGLQt6VideoItem {" +
-                    "    objectName: \"receiverVideoItem\";" +
-                    "    anchors.fill: parent;" +
-                    "    forceAspectRatio: false;" +
-                    "    acceptEvents: false" +
-                    "}",
-                    videoHost,
-                    "receiverVideoItem"
-                )
-                backend.setReceiverVideoItem(videoItem)
-            } catch (err) {
-                backend.setReceiverVideoItem(null)
-                page.appendLog("Embedded video unavailable; using fallback player window.")
-                page.appendLog(String(err))
-            }
-        }
     }
 
     Rectangle {

--- a/linux/monitorize/qml/main.qml
+++ b/linux/monitorize/qml/main.qml
@@ -97,10 +97,10 @@ Rectangle {
         objectName: "mainStack"
         property string lastStreamingSetupPage: "MainMenuPage.qml"
         anchors.fill: parent
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.topMargin: 56
-        anchors.bottomMargin: 20
+        anchors.leftMargin: backend.isReceiving ? 0 : 20
+        anchors.rightMargin: backend.isReceiving ? 0 : 20
+        anchors.topMargin: backend.isReceiving ? 0 : 56
+        anchors.bottomMargin: backend.isReceiving ? 0 : 20
         initialItem: "MainMenuPage.qml"
 
         pushEnter: Transition {
@@ -160,6 +160,7 @@ Rectangle {
         z: 2
         width: 36
         height: 36
+        visible: !backend.isReceiving
         text: "⚙"
         ToolTip.visible: hovered
         ToolTip.text: "Settings"

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -438,6 +438,20 @@ class ReceiverControllerTest(unittest.TestCase):
         controller._sync_embedded_sink_geometry(sink)
         sink.set_render_rectangle.assert_called_once_with(0, 0, 1, 1)
 
+    def test_embedded_video_geometry_logs_tiny_surface_once(self):
+        controller = ReceiverController("kde", Mock())
+        video_item = Mock()
+        video_item.width.return_value = 32
+        video_item.height.return_value = 24
+        sink = Mock()
+        emitted = []
+        controller.video_item = video_item
+        controller.logAppended.connect(emitted.append)
+        controller._sync_embedded_sink_geometry(sink)
+        controller._sync_embedded_sink_geometry(sink)
+        self.assertEqual(len(emitted), 1)
+        self.assertIn("32x24", emitted[0])
+
     def test_embedded_pipeline_can_mark_receiver_stable(self):
         controller = ReceiverController("kde", Mock())
         controller.generation = 6
@@ -552,6 +566,73 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertEqual(controller.sink, "autovideosink")
         self.assertEqual(controller.decoder_args, ["avdec_h264"])
         self.assertTrue(controller.pipeline_fallback_used)
+
+
+class ReceiverVideoWindowTest(unittest.TestCase):
+    def test_receiver_video_window_fills_native_surface_from_window_size(self):
+        from monitorize.desktop.main_window import ReceiverVideoWindow
+
+        backend = Mock()
+        window = Mock()
+        window.backend = backend
+        window.width.return_value = 1920
+        window.height.return_value = 1080
+        window.video_surface = Mock()
+        ReceiverVideoWindow.sync_video_geometry(window)
+        window.video_surface.setGeometry.assert_called_once_with(0, 0, 1920, 1080)
+        backend.receiver.sync_video_geometry.assert_called_once()
+
+    def test_receiver_video_window_waits_for_valid_surface_before_binding(self):
+        from monitorize.desktop.main_window import ReceiverVideoWindow
+
+        backend = Mock()
+        backend.isReceiving = True
+        window = Mock()
+        window.backend = backend
+        window.SYNC_DELAYS_MS = ReceiverVideoWindow.SYNC_DELAYS_MS
+        window.isVisible.return_value = True
+        window.video_surface = Mock()
+        window.video_surface.width.return_value = 1
+        window.video_surface.height.return_value = 1080
+        window.sync_video_geometry = Mock()
+        with patch("monitorize.desktop.main_window.QTimer.singleShot") as single_shot:
+            ReceiverVideoWindow._bind_receiver_video_surface(window)
+        backend.setReceiverVideoItem.assert_not_called()
+        single_shot.assert_called_once()
+
+    def test_receiver_video_window_binds_and_schedules_geometry_resyncs(self):
+        from monitorize.desktop.main_window import ReceiverVideoWindow
+
+        backend = Mock()
+        backend.isReceiving = True
+        window = Mock()
+        window.backend = backend
+        window.SYNC_DELAYS_MS = ReceiverVideoWindow.SYNC_DELAYS_MS
+        window.isVisible.return_value = True
+        window.video_surface = Mock()
+        window.video_surface.width.return_value = 1920
+        window.video_surface.height.return_value = 1080
+        window.sync_video_geometry = Mock()
+        with patch("monitorize.desktop.main_window.QTimer.singleShot") as single_shot:
+            ReceiverVideoWindow._bind_receiver_video_surface(window)
+        backend.setReceiverVideoItem.assert_called_once_with(window.video_surface)
+        self.assertEqual(single_shot.call_count, len(ReceiverVideoWindow.SYNC_DELAYS_MS))
+
+    def test_monitorize_window_uses_dedicated_receiver_window(self):
+        from monitorize.desktop.main_window import MonitorizeWindow
+
+        window = Mock()
+        MonitorizeWindow._sync_receiver_fullscreen(window, True)
+        window.receiver_video_window.show_receiver.assert_called_once()
+        window.showFullScreen.assert_not_called()
+        window.content_stack.setCurrentWidget.assert_not_called()
+
+    def test_monitorize_window_hides_dedicated_receiver_window_on_stop(self):
+        from monitorize.desktop.main_window import MonitorizeWindow
+
+        window = Mock()
+        MonitorizeWindow._sync_receiver_fullscreen(window, False)
+        window.receiver_video_window.hide_receiver.assert_called_once()
 
     def test_stale_credentials_request_pairing_again(self):
         controller = ReceiverController("kde", Mock())

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -352,18 +352,19 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIn("force-aspect-ratio=false", args)
         self.assertIn("port=7114", args)
 
-    def test_embedded_pipeline_uses_qt6_video_sink(self):
+    def test_embedded_pipeline_uses_video_overlay_sink(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["avdec_h264"]
         with patch(
             "monitorize.desktop.receiver_controller._gst_has_property",
             return_value=True,
         ):
-            description = controller._embedded_pipeline_description("10.0.0.2", 7110)
-        self.assertIn("qml6glsink", description)
+            description = controller._embedded_pipeline_description(
+                "10.0.0.2", 7110, "glimagesink"
+            )
+        self.assertIn("glimagesink", description)
         self.assertIn("name=receiver_sink", description)
-        self.assertIn("glupload", description)
-        self.assertIn("glcolorconvert", description)
+        self.assertIn("videoconvert", description)
         self.assertIn("force-aspect-ratio=false", description)
 
     def test_receiver_waits_for_embedded_video_surface(self):

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -416,6 +416,28 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIsNone(controller.pending_launch)
         self.assertFalse(controller.surface_timer.isActive())
 
+    def test_embedded_video_geometry_syncs_render_rectangle(self):
+        controller = ReceiverController("kde", Mock())
+        video_item = Mock()
+        video_item.width.return_value = 1920
+        video_item.height.return_value = 1080
+        sink = Mock()
+        controller.video_item = video_item
+        controller.gst_video_sink = sink
+        controller.sync_video_geometry()
+        sink.set_render_rectangle.assert_called_once_with(0, 0, 1920, 1080)
+        sink.expose.assert_called_once()
+
+    def test_embedded_video_geometry_clamps_zero_size(self):
+        controller = ReceiverController("kde", Mock())
+        video_item = Mock()
+        video_item.width.return_value = 0
+        video_item.height.return_value = 0
+        sink = Mock()
+        controller.video_item = video_item
+        controller._sync_embedded_sink_geometry(sink)
+        sink.set_render_rectangle.assert_called_once_with(0, 0, 1, 1)
+
     def test_embedded_pipeline_can_mark_receiver_stable(self):
         controller = ReceiverController("kde", Mock())
         controller.generation = 6

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -352,6 +352,75 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIn("force-aspect-ratio=false", args)
         self.assertIn("port=7114", args)
 
+    def test_embedded_pipeline_uses_qt6_video_sink(self):
+        controller = ReceiverController("kde", Mock())
+        controller.decoder_args = ["avdec_h264"]
+        with patch(
+            "monitorize.desktop.receiver_controller._gst_has_property",
+            return_value=True,
+        ):
+            description = controller._embedded_pipeline_description("10.0.0.2", 7110)
+        self.assertIn("qml6glsink", description)
+        self.assertIn("name=receiver_sink", description)
+        self.assertIn("glupload", description)
+        self.assertIn("glcolorconvert", description)
+        self.assertIn("force-aspect-ratio=false", description)
+
+    def test_receiver_waits_for_embedded_video_surface(self):
+        controller = ReceiverController("kde", Mock())
+        controller.decoder_args = ["avdec_h264"]
+        controller.decoder_label = "Software"
+        with (
+            patch.object(controller, "_should_wait_for_embedded_surface", return_value=True),
+            patch.object(controller, "_launch_external_pipeline") as external,
+        ):
+            controller._launch_pipeline("10.0.0.2", 7110, generation=0)
+        external.assert_not_called()
+        self.assertEqual(controller.pending_launch, ("10.0.0.2", 7110, 0))
+        self.assertTrue(controller.surface_timer.isActive())
+        controller.surface_timer.stop()
+
+    def test_receiver_video_item_starts_pending_pipeline(self):
+        controller = ReceiverController("kde", Mock())
+        controller.pending_launch = ("10.0.0.2", 7110, 3)
+        controller.surface_timer.start(1000)
+        with patch.object(controller, "_launch_pipeline") as launch:
+            controller.set_video_item(Mock())
+        launch.assert_called_once_with("10.0.0.2", 7110, 3)
+        self.assertIsNone(controller.pending_launch)
+        self.assertFalse(controller.surface_timer.isActive())
+
+    def test_embedded_pipeline_can_mark_receiver_stable(self):
+        controller = ReceiverController("kde", Mock())
+        controller.generation = 6
+        controller.host = "10.0.0.2"
+        controller.port = 7110
+        pipeline = object()
+        controller.gst_pipeline = pipeline
+        with patch.object(controller, "_inhibit_sleep"):
+            controller._mark_stable(6, pipeline)
+        self.assertTrue(controller.stable)
+        self.assertTrue(controller.receiving)
+        self.assertEqual(controller.status, "Receiving from 10.0.0.2:7110")
+
+    def test_receiver_connect_marks_session_active_before_stable(self):
+        controller = ReceiverController("kde", Mock())
+        emitted = []
+        controller.receivingChanged.connect(lambda value: emitted.append(value))
+        with patch.object(controller, "_start_attempt") as start:
+            controller.connect("10.0.0.2", 7110, False, "", "", "Software")
+        start.assert_called_once()
+        self.assertTrue(controller.receiving)
+        self.assertFalse(controller.stable)
+        self.assertIn(True, emitted)
+
+    def test_encrypted_receiver_waits_for_tls_ready_before_session_active(self):
+        controller = ReceiverController("kde", Mock())
+        with patch.object(controller, "_start_attempt") as start:
+            controller.connect("10.0.0.2", 7110, True, "fingerprint", "", "Software")
+        start.assert_called_once()
+        self.assertFalse(controller.receiving)
+
     def test_software_decoder_discards_corrupt_output_when_supported(self):
         controller = ReceiverController("kde", Mock())
         with patch(
@@ -402,6 +471,16 @@ class ReceiverControllerTest(unittest.TestCase):
             args = controller._sink_args("glimagesink")
         self.assertEqual(args, ["glimagesink", "sync=false", "force-aspect-ratio=false"])
 
+    def test_wayland_fallback_sink_requests_fullscreen_when_supported(self):
+        controller = ReceiverController("kde", Mock())
+        with patch(
+            "monitorize.desktop.receiver_controller._gst_has_property",
+            side_effect=lambda _element, prop: prop in {"fullscreen", "force-aspect-ratio"},
+        ):
+            args = controller._sink_args("waylandsink")
+        self.assertIn("fullscreen=true", args)
+        self.assertIn("force-aspect-ratio=false", args)
+
     def test_immediate_receiver_failure_retries_once_with_fallback_pipeline(self):
         controller = ReceiverController("kde", Mock())
         controller.generation = 4
@@ -417,7 +496,7 @@ class ReceiverControllerTest(unittest.TestCase):
         controller.process = process_mock()
         controller.attempt_started = __import__("time").monotonic()
         with (
-            patch.object(controller, "_launch_pipeline") as launch,
+            patch.object(controller, "_launch_external_pipeline") as launch,
             patch.object(controller, "_software_decoder_args", return_value=["avdec_h264"]),
         ):
             controller._finished(1, None, controller.process, generation=4)
@@ -466,6 +545,18 @@ class ReceiverControllerTest(unittest.TestCase):
         with patch.object(controller, "_launch_pipeline") as launch:
             controller._read_tls(old_tls, generation=1)
         launch.assert_not_called()
+
+    def test_tls_ready_enters_receiver_session_and_launches_pipeline(self):
+        controller = ReceiverController("kde", Mock())
+        controller.generation = 2
+        controller.host = "10.0.0.2"
+        controller.port = 7110
+        controller.tls_process = process_mock()
+        controller.tls_process.readAllStandardOutput.return_value = b"[TLS RECEIVER] READY\n"
+        with patch.object(controller, "_launch_pipeline") as launch:
+            controller._read_tls(controller.tls_process, generation=2)
+        launch.assert_called_once_with("127.0.0.1", 17110, 2)
+        self.assertTrue(controller.receiving)
 
     def test_stale_receiver_finish_does_not_retry(self):
         controller = ReceiverController("kde", Mock())

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -355,6 +355,8 @@ class ReceiverControllerTest(unittest.TestCase):
     def test_embedded_pipeline_uses_video_overlay_sink(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["avdec_h264"]
+        controller.receiver_surface_width = 1920
+        controller.receiver_surface_height = 1080
         with patch(
             "monitorize.desktop.receiver_controller._gst_has_property",
             return_value=True,
@@ -365,7 +367,18 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIn("glimagesink", description)
         self.assertIn("name=receiver_sink", description)
         self.assertIn("videoconvert", description)
+        self.assertIn("videoscale add-borders=false", description)
+        self.assertIn(
+            "video/x-raw,width=1920,height=1080,pixel-aspect-ratio=1/1",
+            description,
+        )
         self.assertIn("force-aspect-ratio=false", description)
+        parts = description.split()
+        decoder_index = parts.index("avdec_h264")
+        first_queue_index = parts.index("queue")
+        self.assertLess(first_queue_index, decoder_index)
+        self.assertNotIn("leaky=downstream", parts[first_queue_index:decoder_index])
+        self.assertIn("leaky=downstream", parts[decoder_index:])
 
     def test_embedded_sink_prefers_wayland_on_wayland(self):
         controller = ReceiverController("kde", Mock())
@@ -381,6 +394,8 @@ class ReceiverControllerTest(unittest.TestCase):
     def test_embedded_wayland_sink_does_not_request_standalone_fullscreen(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["avdec_h264"]
+        controller.receiver_surface_width = 1920
+        controller.receiver_surface_height = 1080
         with patch(
             "monitorize.desktop.receiver_controller._gst_has_property",
             return_value=True,
@@ -410,11 +425,46 @@ class ReceiverControllerTest(unittest.TestCase):
         controller = ReceiverController("kde", Mock())
         controller.pending_launch = ("10.0.0.2", 7110, 3)
         controller.surface_timer.start(1000)
+        item = Mock()
+        item.width.return_value = 1920
+        item.height.return_value = 1080
         with patch.object(controller, "_launch_pipeline") as launch:
-            controller.set_video_item(Mock())
+            controller.set_video_item(item)
         launch.assert_called_once_with("10.0.0.2", 7110, 3)
+        self.assertEqual(controller.receiver_surface_width, 1920)
+        self.assertEqual(controller.receiver_surface_height, 1080)
         self.assertIsNone(controller.pending_launch)
         self.assertFalse(controller.surface_timer.isActive())
+
+    def test_receiver_video_item_waits_when_surface_is_tiny(self):
+        controller = ReceiverController("kde", Mock())
+        controller.pending_launch = ("10.0.0.2", 7110, 3)
+        item = Mock()
+        item.width.return_value = 1
+        item.height.return_value = 1080
+        with patch.object(controller, "_launch_pipeline") as launch:
+            controller.set_video_item(item)
+        launch.assert_not_called()
+        self.assertEqual(controller.pending_launch, ("10.0.0.2", 7110, 3))
+        self.assertTrue(controller.surface_timer.isActive())
+        controller.surface_timer.stop()
+
+    def test_embedded_pipeline_uses_same_scaling_for_primary_and_third_ports(self):
+        controller = ReceiverController("kde", Mock())
+        controller.decoder_args = ["avdec_h264"]
+        controller.receiver_surface_width = 1366
+        controller.receiver_surface_height = 768
+        primary = controller._embedded_pipeline_description(
+            "10.0.0.2", 7110, "waylandsink"
+        )
+        third = controller._embedded_pipeline_description(
+            "10.0.0.2", 7114, "waylandsink"
+        )
+        scaled_caps = "video/x-raw,width=1366,height=768,pixel-aspect-ratio=1/1"
+        self.assertIn("port=7110", primary)
+        self.assertIn("port=7114", third)
+        self.assertIn(scaled_caps, primary)
+        self.assertIn(scaled_caps, third)
 
     def test_embedded_video_geometry_syncs_render_rectangle(self):
         controller = ReceiverController("kde", Mock())
@@ -451,6 +501,35 @@ class ReceiverControllerTest(unittest.TestCase):
         controller._sync_embedded_sink_geometry(sink)
         self.assertEqual(len(emitted), 1)
         self.assertIn("32x24", emitted[0])
+
+    def test_receiver_resize_schedules_one_embedded_pipeline_restart(self):
+        controller = ReceiverController("kde", Mock())
+        video_item = Mock()
+        video_item.width.return_value = 1920
+        video_item.height.return_value = 1080
+        sink = Mock()
+        controller.video_item = video_item
+        controller.gst_video_sink = sink
+        controller.gst_pipeline = object()
+        controller.embedded_pipeline_size = (1280, 720)
+        controller.resize_restart_timer.start = Mock()
+        controller.sync_video_geometry()
+        controller.resize_restart_timer.start.assert_called_once_with(150)
+
+    def test_receiver_resize_restart_relaunches_embedded_pipeline_once(self):
+        controller = ReceiverController("kde", Mock())
+        controller.generation = 5
+        controller.receiver_host = "10.0.0.2"
+        controller.receiver_port = 7110
+        controller.video_item = Mock()
+        controller.receiver_surface_width = 1920
+        controller.receiver_surface_height = 1080
+        controller.gst_pipeline = object()
+        with patch.object(controller, "_launch_embedded_pipeline") as launch:
+            controller._restart_embedded_for_resize(5)
+            controller._restart_embedded_for_resize(5)
+        launch.assert_called_once_with("10.0.0.2", 7110, 5)
+        self.assertTrue(controller.resize_restart_used)
 
     def test_embedded_pipeline_can_mark_receiver_stable(self):
         controller = ReceiverController("kde", Mock())

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -391,6 +391,53 @@ class ReceiverControllerTest(unittest.TestCase):
         ):
             self.assertEqual(controller._embedded_sink_name(), "waylandsink")
 
+    def test_wayland_receivers_default_to_external_sink(self):
+        for de in ("kde", "gnome", "hyprland"):
+            controller = ReceiverController(de, Mock())
+            with (
+                patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+                patch(
+                    "monitorize.desktop.receiver_controller.gst_has_element",
+                    side_effect=lambda name: name in {"waylandsink", "glimagesink"},
+                ),
+            ):
+                self.assertFalse(controller.should_use_embedded_window(), de)
+
+    def test_wayland_receiver_can_force_embedded_for_debugging(self):
+        controller = ReceiverController("gnome", Mock())
+        with (
+            patch.dict(os.environ, {
+                "XDG_SESSION_TYPE": "wayland",
+                "WAYLAND_DISPLAY": "wayland-0",
+                "MONITORIZE_RECEIVER_EMBEDDED": "1",
+            }, clear=True),
+            patch(
+                "monitorize.desktop.receiver_controller.gst_has_element",
+                side_effect=lambda name: name in {"waylandsink", "glimagesink"},
+            ),
+        ):
+            self.assertTrue(controller.should_use_embedded_window())
+
+    def test_wayland_receiver_launches_external_even_with_video_item(self):
+        controller = ReceiverController("gnome", Mock())
+        controller.decoder_args = ["avdec_h264"]
+        controller.decoder_label = "Software"
+        controller.video_item = Mock()
+        controller.video_item.width.return_value = 1920
+        controller.video_item.height.return_value = 1080
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+            patch(
+                "monitorize.desktop.receiver_controller.gst_has_element",
+                side_effect=lambda name: name in {"waylandsink", "glimagesink"},
+            ),
+            patch.object(controller, "_launch_external_pipeline") as external,
+            patch.object(controller, "_launch_embedded_pipeline") as embedded,
+        ):
+            controller._launch_pipeline("10.0.0.2", 7110, generation=0)
+        embedded.assert_not_called()
+        external.assert_called_once_with("10.0.0.2", 7110, 0)
+
     def test_embedded_wayland_sink_does_not_request_standalone_fullscreen(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["avdec_h264"]
@@ -701,10 +748,19 @@ class ReceiverVideoWindowTest(unittest.TestCase):
         from monitorize.desktop.main_window import MonitorizeWindow
 
         window = Mock()
+        window.backend.receiver.should_use_embedded_window.return_value = True
         MonitorizeWindow._sync_receiver_fullscreen(window, True)
         window.receiver_video_window.show_receiver.assert_called_once()
         window.showFullScreen.assert_not_called()
         window.content_stack.setCurrentWidget.assert_not_called()
+
+    def test_monitorize_window_does_not_cover_external_receiver_sink(self):
+        from monitorize.desktop.main_window import MonitorizeWindow
+
+        window = Mock()
+        window.backend.receiver.should_use_embedded_window.return_value = False
+        MonitorizeWindow._sync_receiver_fullscreen(window, True)
+        window.receiver_video_window.show_receiver.assert_not_called()
 
     def test_monitorize_window_hides_dedicated_receiver_window_on_stop(self):
         from monitorize.desktop.main_window import MonitorizeWindow

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -367,6 +367,31 @@ class ReceiverControllerTest(unittest.TestCase):
         self.assertIn("videoconvert", description)
         self.assertIn("force-aspect-ratio=false", description)
 
+    def test_embedded_sink_prefers_wayland_on_wayland(self):
+        controller = ReceiverController("kde", Mock())
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+            patch(
+                "monitorize.desktop.receiver_controller.gst_has_element",
+                side_effect=lambda name: name in {"waylandsink", "glimagesink"},
+            ),
+        ):
+            self.assertEqual(controller._embedded_sink_name(), "waylandsink")
+
+    def test_embedded_wayland_sink_does_not_request_standalone_fullscreen(self):
+        controller = ReceiverController("kde", Mock())
+        controller.decoder_args = ["avdec_h264"]
+        with patch(
+            "monitorize.desktop.receiver_controller._gst_has_property",
+            return_value=True,
+        ):
+            description = controller._embedded_pipeline_description(
+                "10.0.0.2", 7110, "waylandsink"
+            )
+        self.assertIn("waylandsink", description)
+        self.assertNotIn("fullscreen=true", description)
+        self.assertIn("force-aspect-ratio=false", description)
+
     def test_receiver_waits_for_embedded_video_surface(self):
         controller = ReceiverController("kde", Mock())
         controller.decoder_args = ["avdec_h264"]


### PR DESCRIPTION
## Summary by Sourcery

Add robust fullscreen receiver support and improve video surface handling across Linux and Android, including embedded window rendering, stability tracking, and codec/first-frame handling.

New Features:
- Introduce a dedicated native fullscreen receiver window on Linux that embeds the video surface instead of relying on external player windows.
- Add QML overlays for receiver status, disconnect control, and compact log display over the fullscreen video surface.
- Enable Android receivers to track first-frame rendering and report video surface readiness via callbacks and timeouts.

Bug Fixes:
- Ensure Wayland sessions default to external sinks to avoid crashes or tiny embedded rendering, with optional debugging override.
- Prevent premature or failed reconnect loops by distinguishing between an active, stable receiver session and initial connection attempts.
- Avoid launching streams when the embedded video surface is not yet sized correctly, with retries and fallbacks to external windows.
- Fix Android receiver behavior when H.264 codec config and keyframes arrive out of order by buffering SPS/PPS and prepending them to the first decoded frame.
- Detect and report Android video surfaces that never render, triggering a controlled reconnect instead of hanging.
- Ensure TLS READY correctly marks receiver sessions active before pipeline launch, aligning encrypted and unencrypted flows.

Enhancements:
- Add embedded GStreamer pipeline support on Linux using VideoOverlay sinks with dynamic geometry sync and resize-triggered restarts.
- Refine sink selection and properties to prefer windowless fullscreen on supported platforms and request fullscreen only for fallback Wayland sinks.
- Simplify receiver logging UI by limiting log history and rendering plain text instead of rich HTML.
- Cache GStreamer imports and provide timers for polling the bus to mark embedded pipelines stable and handle EOS/errors.
- Adjust main QML layout margins and settings visibility when receiving to better align with fullscreen workflows.

Build:
- Bump Android app version from 0.2.4 to 0.2.5.

Tests:
- Add extensive unit tests for embedded receiver pipeline descriptions, sink selection, geometry sync, and resize restart behavior on Linux.
- Add tests for the dedicated ReceiverVideoWindow and MonitorizeWindow fullscreen coordination logic.
- Add tests validating TLS READY handling, receiver session activation ordering, and fallback pipeline retries.
- Add Android-side tests around surface and streaming callbacks where applicable (structure prepared in Kotlin codebase).