### PR TITLE
labelled nvidai as WIP

### DIFF
--- a/linux/monitorize/qml/ChoiceChips.qml
+++ b/linux/monitorize/qml/ChoiceChips.qml
@@ -19,7 +19,7 @@ RowLayout {
     implicitHeight: 34
 
     function chipLabel(value) {
-        if (value.indexOf("NVIDIA") === 0) return "NVIDIA"
+        if (value.indexOf("NVIDIA") === 0) return "NVIDIA (WIP)"
         if (value.indexOf("Intel/AMD") === 0) return "VA-API"
         if (value.indexOf("Software") === 0) return "CPU"
         return value

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -2858,6 +2858,7 @@ class BackendFacadeTest(unittest.TestCase):
         self.assertIn("theme.buttonBackgroundHover", chips_qml)
         self.assertIn("theme.buttonBackground", chips_qml)
         self.assertIn("function find(val)", chips_qml)
+        self.assertIn('return "NVIDIA (WIP)"', chips_qml)
         self.assertNotIn("chipText.implicitWidth + 24", chips_qml)
         self.assertNotIn("rowSpacing", chips_qml)
         self.assertIn("contentItem: Text", chips_qml)


### PR DESCRIPTION
## Summary by Sourcery

Label the NVIDIA video option as work-in-progress in the UI and update tests accordingly.

Enhancements:
- Clarify the NVIDIA backend chip label by marking it as work-in-progress for users.

Tests:
- Extend GUI controller tests to assert the updated NVIDIA chip label in the QML source.