### PR TITLE
chore: add nix flake 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,9 @@ skills-lock.json
 AI-Wiki/
 AGENTS.md
 docs/
+
+# ==============================
+#  Nix build artifacts
+# ==============================
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -262,6 +262,56 @@ sudo apt install -y \
 
 ---
 
+## <img src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nix-snowflake-colours.svg" height="28" alt="NixOS"> NixOS / Nix (Flake)
+
+A Nix flake is included — all dependencies are handled automatically.
+
+### Try without installing:
+
+```bash
+nix run github:vinnavannewton/ProjectMonitorize
+```
+
+### Install on NixOS (declarative):
+
+Add the flake to your system configuration:
+
+```nix
+# flake.nix
+{
+  inputs.monitorize.url = "github:vinnavannewton/ProjectMonitorize";
+
+  outputs = { nixpkgs, monitorize, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        monitorize.nixosModules.default
+        { programs.monitorize.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+This installs the app, sets up the uinput udev rule, and makes it available in your application menu.
+
+### Install imperatively (any distro with Nix):
+
+```bash
+nix profile install github:vinnavannewton/ProjectMonitorize
+```
+
+### Desktop-Specific (NixOS):
+
+KDE Plasma and Hyprland tools (`kscreen-doctor`, `wlr-randr`) are bundled in the package wrapper — no extra packages needed.
+
+For **GNOME**, add to your NixOS config:
+
+```nix
+environment.variables.MUTTER_DEBUG_DISABLE_HW_CURSORS = "1";
+```
+
+---
+
 ## Running the Application:
 
 1.After starting the stream in the desktop application make sure you go to your display settings and configure the newly created virtual display.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,12 @@ Add the flake to your system configuration:
 }
 ```
 
-This installs the app, sets up the uinput udev rule, and makes it available in your application menu.
+This installs the app, creates a dedicated `monitorize-input` group for uinput access, and makes it available in your application menu.
+
+> **Grant uinput access** — add your user to the `monitorize-input` group in your NixOS config:
+> ```nix
+> users.users.<yourname>.extraGroups = [ "monitorize-input" ];
+> ```
 
 ### Install imperatively (any distro with Nix):
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Monitorize – turn your Android / Linux laptop into a secondary monitor for your Linux desktop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # ── Overlay ────────────────────────────────────────────────────────
+      overlay = final: prev: {
+        monitorize = final.callPackage ./nix/package.nix { };
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        };
+      in
+      {
+        packages = {
+          monitorize = pkgs.monitorize;
+          default = pkgs.monitorize;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${pkgs.monitorize}/bin/monitorize";
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ pkgs.monitorize ];
+          packages = with pkgs; [
+            python3Packages.pytest
+          ];
+        };
+      }
+    ) // {
+      # ── Flake-level outputs (not per-system) ─────────────────────────
+      overlays.default = overlay;
+
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.monitorize;
+        in
+        {
+          options.programs.monitorize = {
+            enable = lib.mkEnableOption "Monitorize – Android / Linux secondary monitor";
+          };
+
+          config = lib.mkIf cfg.enable {
+            nixpkgs.overlays = [ overlay ];
+            environment.systemPackages = [ pkgs.monitorize ];
+
+            # uinput rule so the input bridge can create virtual devices
+            services.udev.extraRules = ''
+              KERNEL=="uinput", MODE="0660", GROUP="input"
+            '';
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -55,9 +55,17 @@
             nixpkgs.overlays = [ overlay ];
             environment.systemPackages = [ pkgs.monitorize ];
 
-            # uinput rule so the input bridge can create virtual devices
+            # Dedicated group so only explicitly authorised users can create
+            # virtual input devices via uinput.  Using the generic "input"
+            # group would grant that capability to all input-group members,
+            # which is overly permissive on multi-user systems.
+            #
+            # To grant a user access, add them to this group:
+            #   users.users.<name>.extraGroups = [ "monitorize-input" ];
+            users.groups.monitorize-input = { };
+
             services.udev.extraRules = ''
-              KERNEL=="uinput", MODE="0660", GROUP="input"
+              KERNEL=="uinput", MODE="0660", GROUP="monitorize-input"
             '';
           };
         };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,26 +12,20 @@
 , xdg-desktop-portal-gtk
 , copyDesktopItems
 , makeDesktopItem
+, bash
 }:
 
 let
   python = python3Packages.python;
-  pythonPath = python3Packages.makePythonPath [
-    python3Packages.pyqt6
-    python3Packages.pyqt6-sip
-    python3Packages.dbus-python
-    python3Packages.pygobject3
-    python3Packages.zeroconf
-    python3Packages.evdev
-    python3Packages.cryptography
-  ];
 in
 python3Packages.buildPythonApplication rec {
   pname = "monitorize";
   version = "0-unstable";
   pyproject = false;                    # no setup.py / pyproject.toml yet
 
-  src = ../linux;
+  # Use lib.cleanSource to exclude editor artefacts, __pycache__, venv/, etc.
+  # so only the intended tree is packaged and builds remain reproducible.
+  src = lib.cleanSource ../linux;
 
   nativeBuildInputs = [
     qt6.wrapQtAppsHook
@@ -45,6 +39,9 @@ python3Packages.buildPythonApplication rec {
     qt6.qtwayland
   ];
 
+  # Single, authoritative dependency list.
+  # PYTHONPATH in postFixup is derived from this via python3Packages.makePythonPath
+  # so the two can never get out of sync.
   propagatedBuildInputs = [
     python3Packages.pyqt6
     python3Packages.pyqt6-sip
@@ -63,7 +60,6 @@ python3Packages.buildPythonApplication rec {
     gobject-introspection
   ];
 
-
   # ── Install phase ──────────────────────────────────────────────────
   installPhase = ''
     runHook preInstall
@@ -73,13 +69,13 @@ python3Packages.buildPythonApplication rec {
     mkdir -p "$siteDir"
     cp -r monitorize "$siteDir/"
 
-    # Launcher script
+    # Launcher script – use an explicit store bash so the wrapper is
+    # fully hermetic and does not depend on /usr/bin/env or a host bash.
     mkdir -p "$out/bin"
-    cat > "$out/bin/monitorize" <<'WRAPPER'
-    #!/usr/bin/env bash
-    exec @python@ -m monitorize "$@"
+    cat > "$out/bin/monitorize" <<WRAPPER
+    #!${bash}/bin/bash
+    exec ${python}/bin/python3 -m monitorize "\$@"
     WRAPPER
-    substituteInPlace "$out/bin/monitorize" --replace-fail "@python@" "${python}/bin/python3"
     chmod +x "$out/bin/monitorize"
 
     # Icon
@@ -109,9 +105,13 @@ python3Packages.buildPythonApplication rec {
   dontWrapQtApps = true;  # we do it ourselves so we can merge everything
 
   postFixup = ''
+    # Derive PYTHONPATH from propagatedBuildInputs so it never drifts out of
+    # sync with the dependency list above.
+    pythonPath="${python3Packages.makePythonPath propagatedBuildInputs}:$out/${python.sitePackages}"
+
     wrapProgram "$out/bin/monitorize" \
       "''${qtWrapperArgs[@]}" \
-      --prefix PYTHONPATH : "${pythonPath}:$out/${python.sitePackages}" \
+      --prefix PYTHONPATH : "$pythonPath" \
       --prefix PATH : "${lib.makeBinPath [
         gst_all_1.gstreamer
         android-tools

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,151 @@
+{ lib
+, python3Packages
+, qt6
+, gst_all_1
+, pipewire
+, gobject-introspection
+, android-tools
+, kdePackages
+, wlr-randr
+, xdg-desktop-portal
+, xdg-desktop-portal-hyprland
+, xdg-desktop-portal-gtk
+, copyDesktopItems
+, makeDesktopItem
+}:
+
+let
+  python = python3Packages.python;
+  pythonPath = python3Packages.makePythonPath [
+    python3Packages.pyqt6
+    python3Packages.pyqt6-sip
+    python3Packages.dbus-python
+    python3Packages.pygobject3
+    python3Packages.zeroconf
+    python3Packages.evdev
+    python3Packages.cryptography
+  ];
+in
+python3Packages.buildPythonApplication rec {
+  pname = "monitorize";
+  version = "0-unstable";
+  pyproject = false;                    # no setup.py / pyproject.toml yet
+
+  src = ../linux;
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    copyDesktopItems
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative                   # QML engine
+    qt6.qtwayland
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.pyqt6
+    python3Packages.pyqt6-sip
+    python3Packages.dbus-python
+    python3Packages.pygobject3
+    python3Packages.zeroconf
+    python3Packages.evdev
+    python3Packages.cryptography
+    # GStreamer runtime
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    # Introspection typelibs for Gst
+    gobject-introspection
+  ];
+
+
+  # ── Install phase ──────────────────────────────────────────────────
+  installPhase = ''
+    runHook preInstall
+
+    # Python package
+    siteDir="$out/${python.sitePackages}"
+    mkdir -p "$siteDir"
+    cp -r monitorize "$siteDir/"
+
+    # Launcher script
+    mkdir -p "$out/bin"
+    cat > "$out/bin/monitorize" <<'WRAPPER'
+    #!/usr/bin/env bash
+    exec @python@ -m monitorize "$@"
+    WRAPPER
+    substituteInPlace "$out/bin/monitorize" --replace-fail "@python@" "${python}/bin/python3"
+    chmod +x "$out/bin/monitorize"
+
+    # Icon
+    mkdir -p "$out/share/icons/hicolor/192x192/apps"
+    cp monitorize/assets/monitorize_desktop_logo.png \
+       "$out/share/icons/hicolor/192x192/apps/monitorize.png"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "monitorize";
+      desktopName = "Monitorize";
+      comment = "Linux to Android Display Bridge – extend or mirror your desktop to a tablet";
+      exec = "monitorize";
+      icon = "monitorize";
+      terminal = false;
+      categories = [ "Utility" "System" ];
+      keywords = [ "monitor" "display" "tablet" "android" "screen" "extend" "mirror" "streaming" ];
+      startupNotify = true;
+      startupWMClass = "monitorize";
+    })
+  ];
+
+  # ── Wrap the launcher with all required paths ──────────────────────
+  dontWrapQtApps = true;  # we do it ourselves so we can merge everything
+
+  postFixup = ''
+    wrapProgram "$out/bin/monitorize" \
+      "''${qtWrapperArgs[@]}" \
+      --prefix PYTHONPATH : "${pythonPath}:$out/${python.sitePackages}" \
+      --prefix PATH : "${lib.makeBinPath [
+        gst_all_1.gstreamer
+        android-tools
+        kdePackages.libkscreen
+        wlr-randr
+        xdg-desktop-portal
+        xdg-desktop-portal-hyprland
+        xdg-desktop-portal-gtk
+        pipewire
+      ]}" \
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        gst_all_1.gst-plugins-good
+        gst_all_1.gst-plugins-bad
+        gst_all_1.gst-plugins-ugly
+        pipewire
+      ]}" \
+      --prefix GI_TYPELIB_PATH : "${lib.makeSearchPathOutput "out" "lib/girepository-1.0" [
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        gobject-introspection
+      ]}"
+  '';
+
+  # Skip automatic tests (they need a running display server)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Turn your Android / Linux laptop into a secondary monitor for your Linux desktop";
+    homepage = "https://github.com/vinnavannewton/ProjectMonitorize";
+    license = licenses.agpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+    mainProgram = "monitorize";
+  };
+}

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/w0nlirly3xyw2v88yr9whbfnlnllicdk-monitorize-0-unstable

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/w0nlirly3xyw2v88yr9whbfnlnllicdk-monitorize-0-unstable


### PR DESCRIPTION
A nix flake for nix and nixos users to make installing the app easier.

## Summary by Sourcery

Add Nix flake support to package and run the application on NixOS and other Nix-enabled systems.

New Features:
- Provide a Nix flake exposing the application as a package, app, overlay, and NixOS module.
- Add a Nix packaging definition that bundles required runtime tools and desktop integration for the application.
- Document NixOS and Nix usage, including declarative and imperative installation, and desktop-environment-specific setup.