### PR TITLE
Fixed a bug where touch inputs looks for EVD in mirror mode

### DIFF
--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -1260,6 +1260,9 @@ fun StreamSurface(
                         hasSizedSurfaceChange = false
                         callbackSurfaceWidth = 0
                         callbackSurfaceHeight = 0
+                        firstFrameRendered = false
+                        watchdogRestartUsed = false
+                        lastReadinessBlockedLogAt = 0L
                         stopActiveStream()
                     }
 

--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -349,6 +349,8 @@ class StreamingController(QObject):
             args.append("--wifi")
             if self.encrypted:
                 args.append("--local-udp")
+        if self.de == "gnome" and self.display_type == "Mirror":
+            args.append("--gnome-primary")
         if stylus:
             args.append("--stylus-features")
         if stylus and not touch:

--- a/linux/monitorize/input_bridge/daemon.py
+++ b/linux/monitorize/input_bridge/daemon.py
@@ -19,6 +19,7 @@ class InputDaemon:
     def __init__(
         self, width, height, wifi=False, stylus_features=False,
         stylus_only=False, de=None, udp_host="0.0.0.0", udp_port=7113,
+        gnome_primary=False,
     ):
         self.shutdown = threading.Event()
         self.de = de or detect_de()
@@ -26,7 +27,7 @@ class InputDaemon:
         self.udp_host = udp_host
         self.udp_port = udp_port
         self.stylus_features = stylus_features and self.de in UINPUT_DESKTOPS
-        self.geometry = Geometry(self.de, width, height)
+        self.geometry = Geometry(self.de, width, height, gnome_primary=gnome_primary)
         self.backend = UInputBackend(self.geometry, self.shutdown)
         self.dispatcher = InputDispatcher(self.backend, stylus_only)
 

--- a/linux/monitorize/input_bridge/geometry.py
+++ b/linux/monitorize/input_bridge/geometry.py
@@ -66,6 +66,27 @@ def gnome_virtual_monitor_edid_from_state(state):
     return None
 
 
+def gnome_primary_monitor_edid_from_state(state):
+    try:
+        _serial, physical, logical, _props = state
+    except (TypeError, ValueError):
+        return None
+    primary = next((layout for layout in logical if bool(layout[4])), None)
+    if not primary:
+        return None
+    connectors = {str(item[0]) for item in primary[5]}
+    for monitor in physical:
+        try:
+            connector, vendor, product, serial = monitor[0]
+        except (TypeError, ValueError, IndexError):
+            continue
+        if str(connector) in connectors:
+            edid = tuple(str(value) for value in (vendor, product, serial))
+            if all(edid):
+                return edid
+    return None
+
+
 def write_gnome_input_mapping(edid, stylus_features=False):
     try:
         values = [str(value) for value in edid]
@@ -166,10 +187,11 @@ def kde_virtual_output(outputs):
 
 
 class Geometry:
-    def __init__(self, de: str, screen_w: int, screen_h: int):
+    def __init__(self, de: str, screen_w: int, screen_h: int, gnome_primary=False):
         self.de = de
         self.screen_w = screen_w
         self.screen_h = screen_h
+        self.gnome_primary = gnome_primary
         self._cache = None
         self._gnome_devices_mapped = False
 
@@ -288,9 +310,13 @@ class Geometry:
         self._gnome_devices_mapped = False
         deadline = time.monotonic() + timeout
         last_error = None
+        edid_from_state = (
+            gnome_primary_monitor_edid_from_state
+            if self.gnome_primary else gnome_virtual_monitor_edid_from_state
+        )
         while time.monotonic() < deadline:
             try:
-                edid = gnome_virtual_monitor_edid_from_state(self._mutter_state())
+                edid = edid_from_state(self._mutter_state())
                 if edid:
                     mapped = write_gnome_input_mapping(edid, stylus_features)
                     self._gnome_devices_mapped = mapped
@@ -301,7 +327,8 @@ class Geometry:
         if last_error:
             log.warning("Failed to map GNOME uinput devices: %s", last_error)
         else:
-            log.warning("Failed to map GNOME uinput devices: no virtual monitor EDID")
+            target = "primary" if self.gnome_primary else "virtual"
+            log.warning("Failed to map GNOME uinput devices: no %s monitor EDID", target)
         return False
 
     def desktop_bounds(self):

--- a/linux/monitorize/input_bridge/touch_daemon.py
+++ b/linux/monitorize/input_bridge/touch_daemon.py
@@ -25,6 +25,7 @@ def main():
         stylus_only="--stylus-only" in sys.argv,
         udp_host=udp_host,
         udp_port=udp_port,
+        gnome_primary="--gnome-primary" in sys.argv,
     )
     try:
         daemon.run()

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -1250,6 +1250,7 @@ class StreamingControllerTest(unittest.TestCase):
         args = process.start.call_args.args[1]
         self.assertIn("--wifi", args)
         self.assertNotIn("--local-udp", args)
+        self.assertNotIn("--gnome-primary", args)
 
     def test_gnome_encrypted_wifi_input_uses_local_udp(self):
         controller = self.gnome_controller()
@@ -1267,6 +1268,21 @@ class StreamingControllerTest(unittest.TestCase):
         args = process.start.call_args.args[1]
         self.assertIn("--wifi", args)
         self.assertIn("--local-udp", args)
+
+    def test_gnome_mirror_input_targets_primary_monitor(self):
+        controller = self.gnome_controller()
+        controller.display_type = "Mirror"
+        process = process_mock()
+        with (
+            patch("monitorize.desktop.streaming_controller.QProcess", return_value=process),
+            patch(
+                "monitorize.desktop.streaming_controller.load_general_settings",
+                return_value={"enable_touch": True, "enable_stylus_features": False},
+            ),
+        ):
+            controller._launch_input(generation=7)
+        args = process.start.call_args.args[1]
+        self.assertIn("--gnome-primary", args)
 
     def test_gnome_stylus_input_args_are_preserved(self):
         controller = self.gnome_controller()

--- a/linux/tests/test_input_bridge.py
+++ b/linux/tests/test_input_bridge.py
@@ -229,6 +229,12 @@ class DaemonStartupTest(unittest.TestCase):
             daemon = daemon_module.InputDaemon(100, 100, de=de)
             self.assertIsInstance(daemon.backend, UInputBackend)
 
+    def test_gnome_primary_flag_reaches_geometry(self):
+        daemon = daemon_module.InputDaemon(
+            100, 100, de="gnome", gnome_primary=True,
+        )
+        self.assertTrue(daemon.geometry.gnome_primary)
+
     def test_backend_setup_completes_before_transport_starts(self):
         order = []
 
@@ -411,10 +417,33 @@ class GnomeGeometryTest(unittest.TestCase):
             {},
         )
 
+    def gnome_mixed_state(self):
+        mode = (
+            "1920x1200@60", 1920, 1200, 60.0, 1.0, [1.0],
+            {"is-current": True},
+        )
+        primary = ("eDP-1", "DEL", "Built-in Display", "serial-2")
+        virtual = ("Meta-0", "MTR", "Monitorize Virtual", "serial-1")
+        return (
+            1,
+            [(primary, [mode], {}), (virtual, [mode], {})],
+            [
+                (0, 0, 1.0, 0, True, [primary], {}),
+                (1920, 0, 1.0, 0, False, [virtual], {}),
+            ],
+            {},
+        )
+
     def test_gnome_virtual_monitor_edid_from_state(self):
         self.assertEqual(
             geometry.gnome_virtual_monitor_edid_from_state(self.gnome_state()),
             ("MTR", "Monitorize Virtual", "serial-1"),
+        )
+
+    def test_gnome_primary_monitor_edid_from_state(self):
+        self.assertEqual(
+            geometry.gnome_primary_monitor_edid_from_state(self.gnome_mixed_state()),
+            ("DEL", "Built-in Display", "serial-2"),
         )
 
     def test_gnome_virtual_monitor_edid_missing_without_virtual_connector(self):
@@ -501,6 +530,24 @@ class GnomeGeometryTest(unittest.TestCase):
         ):
             self.assertTrue(geom.map_gnome_devices(stylus_features=True))
         self.assertEqual(written, [(("MTR", "Monitorize Virtual", "serial-1"), True)])
+        self.assertTrue(geom._gnome_devices_mapped)
+
+    def test_gnome_map_devices_can_target_primary_monitor(self):
+        geom = geometry.Geometry("gnome", 1920, 1200, gnome_primary=True)
+        written = []
+
+        with (
+            patch.object(geom, "_mutter_state", return_value=self.gnome_mixed_state()),
+            patch(
+                "monitorize.input_bridge.geometry.write_gnome_input_mapping",
+                side_effect=lambda edid, stylus: (
+                    written.append((edid, stylus)) or True
+                ),
+            ),
+        ):
+            self.assertTrue(geom.map_gnome_devices(stylus_features=False))
+
+        self.assertEqual(written, [(("DEL", "Built-in Display", "serial-2"), False)])
         self.assertTrue(geom._gnome_devices_mapped)
 
     def test_gnome_map_devices_failed_write_leaves_devices_unmapped(self):


### PR DESCRIPTION
## Summary by Sourcery

Route GNOME touch input mapping to the primary monitor when mirroring and ensure stream readiness flags are reset on reconnection.

New Features:
- Add support for targeting the GNOME primary monitor when mapping input devices in mirror display mode.

Bug Fixes:
- Fix GNOME touch input in mirror mode by mapping devices using the primary monitor EDID instead of the virtual monitor.
- Reset Android stream readiness and watchdog state when reconnecting to avoid stale flags preventing new streams.

Enhancements:
- Propagate a gnome_primary flag from the touch daemon through the input daemon into geometry to control which monitor EDID is used for GNOME input mapping.
- Improve GNOME input mapping logs to distinguish between missing primary and virtual monitor EDIDs.

Tests:
- Add geometry tests for deriving the primary monitor EDID from GNOME state and mapping devices to the primary monitor.
- Extend input daemon and controller tests to verify gnome_primary flag propagation and CLI argument handling in GNOME mirror mode.
- Update GUI controller tests to cover GNOME mirror input launching with the --gnome-primary flag.