### PR TITLE
 minor tweaks in android UI and fixed a bug where the display wont spawn and keep crashing when used custom resolution values in kde fixed it by approximating the values to kwin accepted values

### DIFF
--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -682,12 +682,24 @@ fun HomeScreen(
         else -> 28.dp
     }
     val topSpacerHeight = when {
-        isTablet -> 100.dp
-        isLandscapeMobile -> 40.dp
-        else -> 60.dp
+        isTablet -> 104.dp
+        isLandscapeMobile -> 56.dp
+        else -> 88.dp
     }
-    val devicesSpacing = if (isLandscapeMobile) 10.dp else 14.dp
+    val devicesSpacing = if (isLandscapeMobile) 12.dp else 22.dp
     val settingsButtonPadding = if (isLandscapeMobile) 16.dp else 24.dp
+    val settingsButtonSize = when {
+        isTablet -> 48.dp
+        isLandscapeMobile -> 36.dp
+        else -> 44.dp
+    }
+    val settingsIconSize = when {
+        isTablet -> 24.dp
+        isLandscapeMobile -> 18.dp
+        else -> 22.dp
+    }
+    val refreshButtonWidth = if (isLandscapeMobile) 82.dp else 94.dp
+    val refreshButtonHeight = if (isLandscapeMobile) 34.dp else 38.dp
     val manualRowPadding = if (isLandscapeMobile) 16.dp else 32.dp
     val manualSpacerHeight = if (isLandscapeMobile) 12.dp else 16.dp
     val manualFieldHeight = if (isLandscapeMobile) 48.dp else 56.dp
@@ -706,13 +718,21 @@ fun HomeScreen(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (isTablet) {
-            IconButton(
-                onClick = onSettingsToggle,
-                modifier = Modifier.align(Alignment.TopEnd).padding(settingsButtonPadding).size(48.dp).background(CardDark, CircleShape)
-            ) {
-                Icon(Icons.Default.Settings, contentDescription = "Settings", tint = Color.White)
-            }
+        IconButton(
+            onClick = onSettingsToggle,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(settingsButtonPadding)
+                .size(settingsButtonSize)
+                .clip(CircleShape)
+                .background(CardDark)
+        ) {
+            Icon(
+                Icons.Default.Settings,
+                contentDescription = "Settings",
+                tint = Color.White,
+                modifier = Modifier.size(settingsIconSize)
+            )
         }
 
         Column(
@@ -732,40 +752,21 @@ fun HomeScreen(
                     fontWeight = FontWeight.Bold,
                     letterSpacing = 2.sp
                 )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(width = refreshButtonWidth, height = refreshButtonHeight)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(GreenAccent)
+                        .border(1.dp, GreenAccent.copy(alpha = 0.65f), RoundedCornerShape(8.dp))
+                        .clickable { onStartDiscovery() }
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(6.dp))
-                            .background(AccentIndigo.copy(alpha = 0.15f))
-                            .border(1.dp, AccentIndigo.copy(alpha = 0.4f), RoundedCornerShape(6.dp))
-                            .clickable { onStartDiscovery() }
-                            .padding(horizontal = 12.dp, vertical = 6.dp)
-                    ) {
-                        Text(
-                            text = "REFRESH",
-                            color = AccentIndigo,
-                            fontSize = 11.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    if (!isTablet) {
-                        IconButton(
-                            onClick = onSettingsToggle,
-                            modifier = Modifier
-                                .size(if (isLandscapeMobile) 32.dp else 36.dp)
-                                .background(CardDark, CircleShape)
-                        ) {
-                            Icon(
-                                Icons.Default.Settings,
-                                contentDescription = "Settings",
-                                tint = Color.White,
-                                modifier = Modifier.size(if (isLandscapeMobile) 18.dp else 20.dp)
-                            )
-                        }
-                    }
+                    Text(
+                        text = "REFRESH",
+                        color = Color.White,
+                        fontSize = if (isLandscapeMobile) 10.sp else 11.sp,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
             }
             Spacer(modifier = Modifier.height(devicesSpacing))

--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -259,7 +259,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     onSurfaceRenderTimeout = {
-                                        status.value = "Video surface did not render; reconnect the receiver"
+                                        status.value = "video surface  did not render, try moving your mouse into the virtual display"
                                     },
                                     onInputEvent = { event, viewW, viewH -> inputSender?.send(event, viewW, viewH) }
                                 )
@@ -273,7 +273,11 @@ class MainActivity : ComponentActivity() {
                             exit = slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(300)),
                             modifier = Modifier.align(Alignment.CenterEnd).zIndex(10f)
                         ) {
-                            val panelWidthFraction = if (isTablet || isLandscapeMobile) 0.45f else 0.85f
+                            val panelWidthFraction = when {
+                                isTablet -> 0.38f
+                                isLandscapeMobile -> 0.42f
+                                else -> 0.74f
+                            }
 
                             Box(modifier = Modifier.fillMaxHeight().fillMaxWidth(panelWidthFraction).background(CardDark).border(1.dp, BorderDark)) {
                                 SettingsPanel(
@@ -1033,14 +1037,21 @@ fun SettingsPanel(
 
     val configuration = LocalConfiguration.current
     val isTablet = configuration.smallestScreenWidthDp >= 600
-    val panelPadding = if (isTablet) 28.dp else 20.dp
+    val panelHorizontalPadding = if (isTablet) 28.dp else 18.dp
+    val panelTopPadding = if (isTablet) 40.dp else 52.dp
+    val panelBottomPadding = if (isTablet) 28.dp else 20.dp
     val titleSize = if (isTablet) 22.sp else 18.sp
     val spacingHeight = if (isTablet) 24.dp else 16.dp
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(panelPadding)
+            .padding(
+                start = panelHorizontalPadding,
+                top = panelTopPadding,
+                end = panelHorizontalPadding,
+                bottom = panelBottomPadding,
+            )
             .verticalScroll(rememberScrollState())
     ) {
         Text("Resolution Settings", fontSize = titleSize, fontWeight = FontWeight.Bold, color = Color.White)

--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -193,7 +193,7 @@ class StreamingController(QObject):
             "MONITORIZE_PORTAL_SELECTOR_HINT",
             "KDE will create a virtual monitor for Monitorize.",
         )
-        self._set_status("Opening KDE virtual display portal…")
+        self._set_status("Opening KDE virtual display…")
         self._set_streaming(True)
         self._launch_streamer()
 
@@ -782,7 +782,12 @@ class StreamingController(QObject):
 
     def _advertise(self, *_args):
         if self.streaming and self.wifi:
-            self.discovery.advertise(self.local_ip, self.encrypted, self.third_ready, self.fps)
+            self.discovery.advertise(
+                self.local_ip,
+                self.encrypted,
+                self.third_ready,
+                getattr(self, "fps", 60),
+            )
 
     def stop(self):
         stopping_kde_portal = self._stopping_kde_portal_streamer()

--- a/linux/monitorize/platform/kde_virtual_monitor.py
+++ b/linux/monitorize/platform/kde_virtual_monitor.py
@@ -8,7 +8,7 @@ from monitorize.config.settings import load_kde_virtual_layout, save_kde_virtual
 
 
 KSCREEN_QUERY = ["kscreen-doctor", "-j"]
-KSCREEN_ATTEMPTS = 20
+KSCREEN_ATTEMPTS = 40
 KSCREEN_RETRY_DELAY = 0.1
 
 
@@ -63,6 +63,26 @@ def _matching_mode(output, width, height, fps):
     )
 
 
+def _rounded_cvt_width(width):
+    remainder = width % 8
+    return width - remainder if remainder else width
+
+
+def _compatible_mode(output, width, height, fps):
+    mode = _matching_mode(output, width, height, fps)
+    if mode:
+        return mode, False
+
+    rounded_width = _rounded_cvt_width(width)
+    if rounded_width == width:
+        return None, False
+
+    mode = _matching_mode(output, rounded_width, height, fps)
+    if mode:
+        return mode, True
+    return None, False
+
+
 def _find_output(name):
     return next(
         (
@@ -87,12 +107,25 @@ def _wait_for(getter, attempts, delay):
 
 def _output_with_mode(output_name, width, height, fps, active=False):
     output = _find_output(output_name)
-    mode = _matching_mode(output or {}, width, height, fps)
+    mode, rounded = _compatible_mode(output or {}, width, height, fps)
     if not output or not mode:
         return None
     if active and str(output.get("currentModeId")) != str(mode.get("id")):
         return None
-    return output, mode
+    return output, mode, rounded
+
+
+def _mode_summary(output):
+    modes = []
+    for mode in output.get("modes", []):
+        size = mode.get("size", {})
+        width = size.get("width")
+        height = size.get("height")
+        refresh = mode.get("refreshRate")
+        mode_id = mode.get("id", "")
+        if width and height and refresh:
+            modes.append(f"{mode_id}:{width}x{height}@{refresh}")
+    return ", ".join(modes) or "none"
 
 
 def _run_kscreen(setting):
@@ -190,24 +223,38 @@ def configure_portal_virtual_output(
         return False, "", "KDE portal virtual output could not be identified safely"
 
     output_name = str(output["name"])
-    mode = _matching_mode(output, width, height, fps)
+    mode, rounded = _compatible_mode(output, width, height, fps)
     if not mode:
-        error = _run_kscreen(
-            (
-                f"output.{output_name}.addCustomMode."
-                f"{width}.{height}.{fps * 1000}.full"
+        found = None
+        errors = []
+        for timing in ("full", "reduced"):
+            error = _run_kscreen(
+                (
+                    f"output.{output_name}.addCustomMode."
+                    f"{width}.{height}.{fps * 1000}.{timing}"
+                )
             )
-        )
-        if error:
-            return False, output_name, f"Could not register KDE custom mode: {error}"
-        found = _wait_for(
-            lambda: _output_with_mode(output_name, width, height, fps),
-            attempts,
-            delay,
-        )
+            if error:
+                errors.append(f"{timing}: {error}")
+                continue
+            found = _wait_for(
+                lambda: _output_with_mode(output_name, width, height, fps),
+                attempts,
+                delay,
+            )
+            if found:
+                break
         if not found:
-            return False, output_name, "KDE did not expose the registered custom mode"
-        output, mode = found
+            output = _find_output(output_name) or output
+            details = f"exposed modes: {_mode_summary(output)}"
+            if errors:
+                details = f"{details}; registration errors: {'; '.join(errors)}"
+            return (
+                False,
+                output_name,
+                f"KDE did not expose the registered custom mode ({details})",
+            )
+        output, mode, rounded = found
 
     mode_id = str(mode.get("id", ""))
     if not mode_id:
@@ -228,11 +275,19 @@ def configure_portal_virtual_output(
         return False, output_name, "KDE did not activate the requested custom mode"
     _position_virtual_output(output_name, kde_outputs())
 
+    size = mode.get("size", {})
+    actual_width = int(size.get("width", width))
+    actual_height = int(size.get("height", height))
+    actual_refresh = float(mode.get("refreshRate", fps))
+    mode_text = f"{actual_width}x{actual_height}@{actual_refresh:g}"
+    if rounded:
+        mode_text = f"{mode_text} (rounded from {width}x{height}@{fps})"
+
     return (
         True,
         output_name,
         (
-            f"Configured {output_name} to {width}x{height}@{fps} "
+            f"Configured {output_name} to {mode_text} "
             "while preserving KDE scale"
         ),
     )

--- a/linux/monitorize/streaming/Streamer_kde.py
+++ b/linux/monitorize/streaming/Streamer_kde.py
@@ -27,6 +27,13 @@ selector_hint = os.environ.get(
     "MONITORIZE_PORTAL_SELECTOR_HINT",
     "Select 'TabletDisplay' in the picker.",
 )
+encoder = get_encoder(os.environ.get("MONITORIZE_ENCODER", "cpu"))
+host = os.environ.get("MONITORIZE_HOST", "0.0.0.0" if server_mode else "127.0.0.1")
+port = int(os.environ.get(
+    "MONITORIZE_PORT",
+    port_override or (7110 if server_mode else 7112),
+))
+
 baseline_names = active_kde_output_names() if source_type == 4 else set()
 prepare_stream = None
 if source_type == 4:
@@ -45,12 +52,9 @@ sys.exit(run_portal_streamer(
     fps,
     bitrate,
     mode,
-    int(os.environ.get(
-        "MONITORIZE_PORT",
-        port_override or (7110 if server_mode else 7112),
-    )),
-    get_encoder(os.environ.get("MONITORIZE_ENCODER", "cpu")),
-    os.environ.get("MONITORIZE_HOST", "0.0.0.0" if server_mode else "127.0.0.1"),
+    port,
+    encoder,
+    host,
     source_type=source_type,
     prepare_stream=prepare_stream,
 ))

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -15,7 +15,11 @@ from PyQt6.QtCore import QCoreApplication, QProcess
 from monitorize.streaming import Streamer_gnome, pipeline_builder
 from monitorize.streaming import portal_streamer
 from monitorize.config import app_log, autostart, settings
-from monitorize.platform import gnome_virtual_monitor, kde_virtual_monitor, process_utils
+from monitorize.platform import (
+    gnome_virtual_monitor,
+    kde_virtual_monitor,
+    process_utils,
+)
 from monitorize.desktop.discovery_service import DiscoveryService
 from monitorize.desktop.backend import MonitorizeBackend
 from monitorize.desktop.receiver_controller import ReceiverController
@@ -1041,7 +1045,7 @@ class StreamingControllerTest(unittest.TestCase):
         self.assertEqual(args[-1], "HEADLESS-2")
         self.assertIn("wifi", args)
         discovery.advertise.assert_called_once_with(
-            "10.0.0.1", False, False
+            "10.0.0.1", False, False, 60
         )
 
     def test_gnome_streamer_command_uses_display_type_only(self):
@@ -1379,6 +1383,7 @@ class StreamingControllerTest(unittest.TestCase):
         controller.wifi = True
         controller.encrypted = False
         controller.primary_ready = True
+        controller.fps = 60
         events = []
         controller.secondStreamChanged.connect(events.append)
         process = process_mock()
@@ -1397,7 +1402,7 @@ class StreamingControllerTest(unittest.TestCase):
         self.assertEqual(env.value("MONITORIZE_PORT"), "7114")
         self.assertNotEqual(env.value("MONITORIZE_PORTAL_SOURCE_TYPE"), "4")
         self.assertEqual(events, [True])
-        discovery.advertise.assert_called_once_with("10.0.0.1", False, False)
+        discovery.advertise.assert_called_once_with("10.0.0.1", False, False, 60)
 
     def test_hyprland_third_display_uses_portal_monitor_picker(self):
         controller = StreamingController("hyprland", "10.0.0.1", Mock())
@@ -1479,7 +1484,7 @@ class StreamingControllerTest(unittest.TestCase):
         self.assertTrue(controller.third_ready)
         self.assertEqual(
             discovery.advertise.call_args_list[-1].args,
-            ("10.0.0.1", False, True),
+            ("10.0.0.1", False, True, 60),
         )
 
     def test_stale_third_streamer_output_is_ignored(self):
@@ -2228,6 +2233,120 @@ class KdeVirtualMonitorCompatTest(unittest.TestCase):
         self.assertFalse(any(".scale." in " ".join(command) for command in commands))
         self.assertFalse(any("output.eDP-1" in " ".join(command) for command in commands))
 
+    def test_portal_mode_registration_tries_reduced_blanking_after_full(self):
+        state = {"registered": False, "active": False}
+
+        def fake_run(args, **_kwargs):
+            if args == ["kscreen-doctor", "-j"]:
+                outputs = self.portal_outputs(
+                    mode_registered=state["registered"],
+                    mode_active=state["active"],
+                )
+                return Mock(
+                    returncode=0,
+                    stdout=json.dumps({"outputs": outputs}),
+                    stderr="",
+                )
+            if "addCustomMode.1920.1200.60000.full" in args[1]:
+                return Mock(returncode=0, stdout="", stderr="")
+            if "addCustomMode.1920.1200.60000.reduced" in args[1]:
+                state["registered"] = True
+                return Mock(returncode=0, stdout="", stderr="")
+            if args[1].endswith(".mode.2"):
+                state["active"] = True
+                return Mock(returncode=0, stdout="", stderr="")
+            if ".position." in args[1] or ".rotation." in args[1]:
+                return Mock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with (
+            patch(
+                "monitorize.platform.kde_virtual_monitor.subprocess.run",
+                side_effect=fake_run,
+            ) as run,
+            patch("monitorize.platform.kde_virtual_monitor.load_kde_virtual_layout",
+                  return_value={"position": None, "rotation": ""}),
+            patch("monitorize.platform.kde_virtual_monitor.time.sleep"),
+        ):
+            ok, _output_name, message = (
+                kde_virtual_monitor.configure_portal_virtual_output(
+                    {"eDP-1"},
+                    1920,
+                    1200,
+                    60,
+                    attempts=1,
+                    delay=0,
+                )
+            )
+
+        self.assertTrue(ok, message)
+        commands = [call.args[0][1] for call in run.call_args_list if len(call.args[0]) > 1]
+        self.assertIn(
+            "output.Virtual-virtual-xdp-kde-monitorize.addCustomMode.1920.1200.60000.full",
+            commands,
+        )
+        self.assertIn(
+            "output.Virtual-virtual-xdp-kde-monitorize.addCustomMode.1920.1200.60000.reduced",
+            commands,
+        )
+
+    def test_portal_mode_registration_accepts_cvt_rounded_width(self):
+        state = {"registered": False, "active": False}
+
+        def rounded_outputs():
+            outputs = self.portal_outputs()
+            if state["registered"]:
+                outputs[0]["modes"].append({
+                    "id": "2",
+                    "name": "2336x1080@60",
+                    "refreshRate": 59.952,
+                    "size": {"width": 2336, "height": 1080},
+                })
+            outputs[0]["currentModeId"] = "2" if state["active"] else "1"
+            return outputs
+
+        def fake_run(args, **_kwargs):
+            if args == ["kscreen-doctor", "-j"]:
+                return Mock(
+                    returncode=0,
+                    stdout=json.dumps({"outputs": rounded_outputs()}),
+                    stderr="",
+                )
+            if "addCustomMode.2340.1080.60000.full" in args[1]:
+                state["registered"] = True
+                return Mock(returncode=0, stdout="", stderr="")
+            if args[1].endswith(".mode.2"):
+                state["active"] = True
+                return Mock(returncode=0, stdout="", stderr="")
+            if ".position." in args[1] or ".rotation." in args[1]:
+                return Mock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with (
+            patch(
+                "monitorize.platform.kde_virtual_monitor.subprocess.run",
+                side_effect=fake_run,
+            ),
+            patch("monitorize.platform.kde_virtual_monitor.load_kde_virtual_layout",
+                  return_value={"position": None, "rotation": ""}),
+            patch("monitorize.platform.kde_virtual_monitor.time.sleep"),
+        ):
+            ok, output_name, message = (
+                kde_virtual_monitor.configure_portal_virtual_output(
+                    {"eDP-1"},
+                    2340,
+                    1080,
+                    60,
+                    attempts=2,
+                    delay=0,
+                )
+            )
+
+        self.assertTrue(ok, message)
+        self.assertEqual(output_name, "Virtual-virtual-xdp-kde-monitorize")
+        self.assertIn("2336x1080", message)
+        self.assertIn("rounded from 2340x1080@60", message)
+
     def test_portal_layout_uses_saved_primary_position_and_rotation(self):
         def fake_run(args, **_kwargs):
             if args == ["kscreen-doctor", "-j"]:
@@ -2937,7 +3056,7 @@ class BackendFacadeTest(unittest.TestCase):
         checkbox_qml = (qml_dir / "CustomCheckBox.qml").read_text(encoding="utf-8")
         self.assertEqual(qml.count("CustomToggle {"), 3)
         self.assertNotIn("CustomCheckBox {", qml)
-        self.assertIn('text: "Encrypted"', qml)
+        self.assertIn('text: "Use encryption"', qml)
         self.assertNotIn('text: "Use encryption (recommended)"', qml)
         self.assertIn("Switch {", toggle_qml)
         self.assertIn("theme.buttonBackgroundHover", toggle_qml)


### PR DESCRIPTION
## Summary by Sourcery

Adjust KDE virtual output handling and Android UI layout while improving discovery advertising for third displays.

Bug Fixes:
- Fix KDE custom resolution crashes by retrying mode registration with full and reduced blanking and accepting CVT-rounded widths.
- Ensure Wi‑Fi discovery advertising always includes an FPS value, defaulting to 60 when unset.
- Clarify Android receiver error message when the video surface fails to render.

Enhancements:
- Increase KDE kscreen polling attempts and provide detailed mode summaries when configuration fails.
- Report the actual KDE mode used (including rounding information) in success messages when configuring virtual outputs.
- Reuse computed encoder, host, and port variables in the KDE streamer instead of recomputing them inline.
- Refine Android home screen and settings panel layout, spacing, and button styling for phones and tablets.
- Update Wi‑Fi/USB settings UI copy for the encryption option.

Tests:
- Extend KDE virtual output tests to cover reduced-blanking fallback and CVT-rounded width handling.
- Update GUI controller tests to assert FPS is passed through to discovery advertising and adjust expected encryption label copy.