### PR TITLE
added copr CI/CD

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+NAME := monitorize
+SPEC := monitorize.spec
+VERSION := $(shell awk '/^Version:/ {print $$2; exit}' $(SPEC))
+outdir ?= .
+rpmbuilddir := $(abspath $(outdir))/rpmbuild
+
+print-version:
+	@printf '%s\n' "$(VERSION)"
+
+srpm:
+	test -n "$(VERSION)"
+	mkdir -p $(outdir) $(rpmbuilddir)/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS,tmp}
+	git archive --format=tar --prefix=$(NAME)-$(VERSION)/ HEAD \
+		pyproject.toml $(SPEC) packaging linux README.md LICENSE COMMERCIAL_LICENSE.md \
+		| gzip -9 > $(outdir)/$(NAME)-$(VERSION).tar.gz
+	rpmbuild -bs $(SPEC) \
+		--define "_topdir $(rpmbuilddir)" \
+		--define "_sourcedir $(abspath $(outdir))" \
+		--define "_srcrpmdir $(abspath $(outdir))" \
+		--define "_tmppath $(rpmbuilddir)/tmp"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     tags:
-      - "v*.*.*"
+      - "android-v*.*.*"
     paths:
       - "android/**"
 
@@ -53,7 +53,7 @@ jobs:
   release:
     name: Android Release
     needs: ci
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/android-v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,15 +80,15 @@ jobs:
       - name: Validate tag matches Gradle versionName
         run: |
           set -euo pipefail
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${GITHUB_REF_NAME#android-v}"
           if ! printf '%s\n' "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Tag $GITHUB_REF_NAME must use vMAJOR.MINOR.PATCH format, for example v0.2.4"
+            echo "Tag $GITHUB_REF_NAME must use android-vMAJOR.MINOR.PATCH format, for example android-v0.2.7"
             exit 1
           fi
 
           GRADLE_VERSION="$(grep -E '^val appVersionName = "' app/build.gradle.kts | sed -E 's/^val appVersionName = "([^"]+)".*/\1/')"
           if [ "$TAG_VERSION" != "$GRADLE_VERSION" ]; then
-            echo "Tag v$TAG_VERSION does not match Android versionName $GRADLE_VERSION"
+            echo "Tag android-v$TAG_VERSION does not match Android versionName $GRADLE_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,204 @@
+name: Desktop
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "linux/**"
+      - "packaging/**"
+      - ".copr/**"
+      - "monitorize.spec"
+      - "pyproject.toml"
+      - "README.md"
+      - ".github/workflows/desktop.yml"
+  push:
+    branches:
+      - main
+    tags:
+      - "desktop-v*.*.*"
+    paths:
+      - "linux/**"
+      - "packaging/**"
+      - ".copr/**"
+      - "monitorize.spec"
+      - "pyproject.toml"
+      - "README.md"
+      - ".github/workflows/desktop.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Desktop CI
+    runs-on: ubuntu-latest
+    container: fedora:44
+    env:
+      QT_QPA_PLATFORM: offscreen
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf -y install \
+            desktop-file-utils \
+            dnf-plugins-core \
+            git \
+            gstreamer1 \
+            gstreamer1-plugin-openh264 \
+            gstreamer1-plugins-bad-free \
+            gstreamer1-plugins-base \
+            gstreamer1-plugins-good \
+            gstreamer1-plugins-ugly-free \
+            iproute \
+            kmod \
+            make \
+            pipewire \
+            pyproject-rpm-macros \
+            python3 \
+            python3-cryptography \
+            python3-dbus \
+            python3-devel \
+            python3-evdev \
+            python3-gobject \
+            python3-pip \
+            python3-pyqt6 \
+            python3-wheel \
+            python3-zeroconf \
+            rpm-build \
+            systemd-udev \
+            util-linux \
+            xdg-desktop-portal
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate desktop version
+        run: |
+          set -euo pipefail
+          SPEC_VERSION="$(awk '/^Version:/ {print $2; exit}' monitorize.spec)"
+          PYPROJECT_VERSION="$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          MAKE_VERSION="$(make -s -f .copr/Makefile print-version)"
+
+          test -n "$SPEC_VERSION"
+          if [ "$SPEC_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "monitorize.spec Version $SPEC_VERSION does not match pyproject.toml version $PYPROJECT_VERSION"
+            exit 1
+          fi
+          if [ "$SPEC_VERSION" != "$MAKE_VERSION" ]; then
+            echo ".copr/Makefile version $MAKE_VERSION does not match monitorize.spec Version $SPEC_VERSION"
+            exit 1
+          fi
+
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            case "$GITHUB_REF_NAME" in
+              desktop-v*) TAG_VERSION="${GITHUB_REF_NAME#desktop-v}" ;;
+              *)
+                echo "Desktop release tags must use desktop-vMAJOR.MINOR.PATCH format, for example desktop-v0.2.7"
+                exit 1
+                ;;
+            esac
+
+            if ! printf '%s\n' "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Tag $GITHUB_REF_NAME must use desktop-vMAJOR.MINOR.PATCH format, for example desktop-v0.2.7"
+              exit 1
+            fi
+
+            if [ "$TAG_VERSION" != "$SPEC_VERSION" ]; then
+              echo "Tag desktop-v$TAG_VERSION does not match desktop package version $SPEC_VERSION"
+              exit 1
+            fi
+          fi
+
+      - name: Validate package files
+        run: |
+          set -euo pipefail
+          python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("pyproject.toml").read_text())'
+          desktop-file-validate packaging/fedora/monitorize.desktop
+          rpmspec -P monitorize.spec >/tmp/monitorize-rpmspec.out
+
+      - name: Run unit tests
+        run: env PYTHONPATH=linux python3 -m unittest discover linux/tests
+
+      - name: Build RPM and SRPM
+        run: |
+          set -euo pipefail
+          mkdir -p dist rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS,tmp}
+          make -f .copr/Makefile srpm outdir="$PWD/dist"
+          rpmbuild -ba monitorize.spec \
+            --define "_topdir $PWD/rpmbuild" \
+            --define "_sourcedir $PWD/dist" \
+            --define "_srcrpmdir $PWD/dist" \
+            --define "_rpmdir $PWD/dist/rpms" \
+            --define "_tmppath $PWD/rpmbuild/tmp"
+          find dist -type f -name '*.rpm' -print
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: monitorize-desktop-rpms
+          path: dist/**/*.rpm
+          if-no-files-found: error
+
+  release:
+    name: Desktop Release
+    needs: ci
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/desktop-v')
+    runs-on: ubuntu-latest
+    container: fedora:44
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install release dependencies
+        run: dnf -y install copr-cli findutils gh
+
+      - name: Download RPM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: monitorize-desktop-rpms
+          path: dist
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          NOTES=$'Monitorize desktop '"$GITHUB_REF_NAME"$'\n\nFedora RPM/SRPM build for GitHub Releases and Copr.'
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "$NOTES"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "$NOTES"
+          fi
+
+      - name: Upload RPMs to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find dist -type f -name '*.rpm' ! -name '*buildreqs*' -print | sort)
+          test "${#assets[@]}" -gt 0
+          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+
+      - name: Configure Copr
+        env:
+          COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
+        run: |
+          set -euo pipefail
+          test -n "$COPR_CONFIG"
+          mkdir -p "$HOME/.config"
+          printf '%s' "$COPR_CONFIG" > "$HOME/.config/copr"
+          chmod 600 "$HOME/.config/copr"
+
+      - name: Submit SRPM to Copr
+        run: |
+          set -euo pipefail
+          SRPM="$(find dist -type f -name '*.src.rpm' ! -name '*buildreqs*' -print -quit)"
+          test -n "$SRPM"
+          copr-cli build vinnavannewton/monitorize "$SRPM"

--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@
   </tr>
 </table>
 
+Fedora Copr packages are published from desktop release tags such as `desktop-v0.2.7`:
+
+```bash
+sudo dnf copr enable vinnavannewton/monitorize
+sudo dnf install monitorize
+sudo usermod -aG monitorize "$USER"
+```
+
+Log out and back in after the `usermod` command to enable touch and stylus input.
+
 ### Android:
 
-**Install the APK from the [Releases](https://github.com/vinnavannewton/project-monitorize/releases/latest) section.**
+**Install the APK from Android releases such as `android-v0.2.7` in the [Releases](https://github.com/vinnavannewton/project-monitorize/releases) section.**
 
 Or build from source:
 

--- a/android/app/src/main/java/com/example/monitorize/MainActivity.kt
+++ b/android/app/src/main/java/com/example/monitorize/MainActivity.kt
@@ -259,7 +259,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     onSurfaceRenderTimeout = {
-                                        status.value = "video surface  did not render, try moving your mouse into the virtual display"
+                                        status.value = "Video surface did not render; try moving your mouse into the virtual display"
                                     },
                                     onInputEvent = { event, viewW, viewH -> inputSender?.send(event, viewW, viewH) }
                                 )

--- a/linux/monitorize/config/autostart.py
+++ b/linux/monitorize/config/autostart.py
@@ -9,6 +9,7 @@ APP_ID = "monitorize"
 DESKTOP_FILE = f"{APP_ID}.desktop"
 START_IN_TRAY_ARG = "--start-in-tray"
 TRAY_AGENT_ARG = "--tray-agent"
+SYSTEM_APPLICATIONS_DIR = Path("/usr/share/applications")
 
 
 def _xdg_config_home():
@@ -24,7 +25,13 @@ def autostart_path():
 
 
 def installed_desktop_path():
-    return _xdg_data_home() / "applications" / DESKTOP_FILE
+    user_entry = _xdg_data_home() / "applications" / DESKTOP_FILE
+    if user_entry.exists():
+        return user_entry
+    system_entry = SYSTEM_APPLICATIONS_DIR / DESKTOP_FILE
+    if system_entry.exists():
+        return system_entry
+    return user_entry
 
 
 def _desktop_quote(value):

--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -29,6 +29,7 @@ from monitorize.config.settings import (
 )
 from monitorize.platform.utils import LINUX_DIR
 from monitorize.config.validation import (
+    DEFAULT_FPS,
     DEFAULT_PRIMARY_RESOLUTION,
     DEFAULT_SECONDARY_RESOLUTION,
     sanitize_bitrate,
@@ -71,6 +72,7 @@ class StreamingController(QObject):
         self.pairing_code = ""
         self.wifi = False
         self.encrypted = False
+        self.fps = DEFAULT_FPS
         self.streamer = self.input_bridge = self.tls_proxy = None
         self.gst_pids = set()
         self.tls_buffer = ""
@@ -786,7 +788,7 @@ class StreamingController(QObject):
                 self.local_ip,
                 self.encrypted,
                 self.third_ready,
-                getattr(self, "fps", 60),
+                self.fps,
             )
 
     def stop(self):

--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -39,6 +39,7 @@ from monitorize.config.validation import (
     sanitize_fps,
     sanitize_resolution,
 )
+from monitorize.input_bridge.uinput_backend import UINPUT_PERMISSION_HINT
 
 
 GNOME_LAYOUT_SAVE_INTERVAL_MS = 1000
@@ -448,11 +449,14 @@ class StreamingController(QObject):
         process = self.input_bridge if process is None else process
         if generation != self.generation or process is not self.input_bridge:
             return
+        raw = bytes(process.readAllStandardOutput()).decode(
+            "utf-8", errors="replace"
+        )
+        if "MONITORIZE_UINPUT_PERMISSION:" in raw:
+            self._set_status(UINPUT_PERMISSION_HINT.split(": ", 1)[1])
         self.logAppended.emit(
             "INPUT",
-            bytes(process.readAllStandardOutput()).decode(
-                "utf-8", errors="replace"
-            ),
+            raw,
         )
 
     def _process_error(self, label, generation, process, current_process):

--- a/linux/monitorize/input_bridge/uinput_backend.py
+++ b/linux/monitorize/input_bridge/uinput_backend.py
@@ -1,5 +1,6 @@
 """evdev/uinput touch and stylus backend."""
 
+import errno
 import logging
 import os
 import threading
@@ -18,6 +19,10 @@ from .geometry import (
 
 log = logging.getLogger("TouchDaemon")
 STYLUS_AXIS_RESOLUTION = 100
+UINPUT_PERMISSION_HINT = (
+    "MONITORIZE_UINPUT_PERMISSION: Monitorize needs uinput permission. "
+    "Run: sudo usermod -aG monitorize \"$USER\" then log out and log back in."
+)
 
 try:
     import evdev
@@ -50,31 +55,38 @@ class UInputBackend:
         self.target = x, y, width, height
         self.rotation = self.geometry.rotation()
         direct = [ecodes.INPUT_PROP_DIRECT] if hasattr(ecodes, "INPUT_PROP_DIRECT") else None
-        self.touch = UInput(
-            self._touch_capabilities(),
-            name="Monitorize-Touch",
-            vendor=MONITORIZE_INPUT_VENDOR_ID,
-            product=MONITORIZE_TOUCH_PRODUCT_ID,
-            bustype=ecodes.BUS_USB,
-            input_props=direct,
-        )
-        if stylus_features:
-            self.stylus = UInput(
-                self._stylus_capabilities(),
-                name="Monitorize-Stylus",
+        try:
+            self.touch = UInput(
+                self._touch_capabilities(),
+                name="Monitorize-Touch",
                 vendor=MONITORIZE_INPUT_VENDOR_ID,
-                product=MONITORIZE_STYLUS_PRODUCT_ID,
+                product=MONITORIZE_TOUCH_PRODUCT_ID,
                 bustype=ecodes.BUS_USB,
                 input_props=direct,
             )
+            if stylus_features:
+                self.stylus = UInput(
+                    self._stylus_capabilities(),
+                    name="Monitorize-Stylus",
+                    vendor=MONITORIZE_INPUT_VENDOR_ID,
+                    product=MONITORIZE_STYLUS_PRODUCT_ID,
+                    bustype=ecodes.BUS_USB,
+                    input_props=direct,
+                )
+        except OSError as exc:
+            if getattr(exc, "errno", None) in (
+                errno.EACCES, errno.EPERM, errno.ENOENT,
+            ):
+                raise RuntimeError(f"{UINPUT_PERMISSION_HINT} ({exc})") from exc
+            raise
         self._map_devices(stylus_features)
         time.sleep(2)
         if self.geometry.de == "kde":
             mapped = self.geometry.map_kde_devices([self.touch, self.stylus])
-            touch_event = os.path.basename(self.touch.device.path)
+            touch_event = self._event_name(self.touch, "Monitorize-Touch")
             if touch_event not in mapped:
                 raise RuntimeError("KDE could not bind Monitorize-Touch to Virtual-TabletDisplay")
-            if self.stylus and os.path.basename(self.stylus.device.path) not in mapped:
+            if self.stylus and self._event_name(self.stylus, "Monitorize-Stylus") not in mapped:
                 self.stylus.close()
                 self.stylus = None
         elif self.geometry.de == "gnome":
@@ -92,6 +104,15 @@ class UInputBackend:
                             "GNOME did not confirm Monitorize-Stylus output mapping; "
                             "stylus pressure may fall back to touch emulation"
                         )
+
+    def _event_name(self, device, label):
+        event_device = getattr(device, "device", None)
+        path = getattr(event_device, "path", "")
+        if not path:
+            raise RuntimeError(
+                f"{UINPUT_PERMISSION_HINT} KDE could not read the {label} event node."
+            )
+        return os.path.basename(path)
 
     def _abs(self, code, minimum, maximum, resolution=0):
         return code, evdev.AbsInfo(0, minimum, maximum, 0, 0, resolution)

--- a/linux/tests/test_gui_controllers.py
+++ b/linux/tests/test_gui_controllers.py
@@ -308,6 +308,30 @@ class AutostartTest(unittest.TestCase):
                 self.assertEqual(autostart.set_enabled(False), "")
                 self.assertFalse(autostart.autostart_path().exists())
 
+    def test_autostart_uses_system_desktop_entry_for_rpm_install(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_home = Path(directory) / "config"
+            data_home = Path(directory) / "data"
+            system_app_dir = Path(directory) / "system-applications"
+            system_app_dir.mkdir()
+            (system_app_dir / "monitorize.desktop").write_text(
+                "[Desktop Entry]\n"
+                "Type=Application\n"
+                "Name=Monitorize\n"
+                "Exec=monitorize\n",
+                encoding="utf-8",
+            )
+            with (
+                patch.dict(os.environ, {
+                    "XDG_CONFIG_HOME": str(config_home),
+                    "XDG_DATA_HOME": str(data_home),
+                }),
+                patch.object(autostart, "SYSTEM_APPLICATIONS_DIR", system_app_dir),
+            ):
+                self.assertEqual(autostart.set_enabled(True), "")
+                content = autostart.autostart_path().read_text(encoding="utf-8")
+        self.assertIn("Exec=monitorize --tray-agent", content)
+
     def test_autostart_falls_back_when_installed_entry_is_missing(self):
         with tempfile.TemporaryDirectory() as directory:
             with patch.dict(os.environ, {
@@ -1313,6 +1337,17 @@ class StreamingControllerTest(unittest.TestCase):
         args = process.start.call_args.args[1]
         self.assertIn("--stylus-features", args)
         self.assertIn("--stylus-only", args)
+
+    def test_input_permission_marker_updates_status(self):
+        controller = self.kde_controller()
+        process = process_mock()
+        process.readAllStandardOutput.return_value = (
+            b"[TouchDaemon] ERROR MONITORIZE_UINPUT_PERMISSION: "
+            b"Monitorize needs uinput permission.\n"
+        )
+        controller.input_bridge = process
+        controller._read_input(generation=3, process=process)
+        self.assertIn("sudo usermod -aG monitorize", controller.status)
 
     def test_runtime_general_settings_override_saved_defaults(self):
         controller = self.kde_controller()

--- a/linux/tests/test_input_bridge.py
+++ b/linux/tests/test_input_bridge.py
@@ -843,6 +843,47 @@ class UInputCreationTest(unittest.TestCase):
         geom.map_gnome_devices.assert_called_once_with(True)
         geom.verify_gnome_devices.assert_called_once_with(devices)
 
+    def test_kde_missing_event_node_reports_permission_hint(self):
+        ecodes = types.SimpleNamespace(
+            EV_ABS=3,
+            EV_KEY=1,
+            ABS_X=0,
+            ABS_Y=1,
+            ABS_MT_SLOT=47,
+            ABS_MT_POSITION_X=53,
+            ABS_MT_POSITION_Y=54,
+            ABS_MT_TRACKING_ID=57,
+            BTN_TOUCH=330,
+            BUS_USB=3,
+            INPUT_PROP_DIRECT=1,
+        )
+        fake_evdev = types.SimpleNamespace(
+            AbsInfo=lambda value, minimum, maximum, fuzz, flat, resolution: (
+                value, minimum, maximum, fuzz, flat, resolution,
+            )
+        )
+        geom = Mock(
+            de="kde",
+            screen_w=1920,
+            screen_h=1200,
+            map_kde_devices=Mock(return_value=set()),
+            uinput_bounds=Mock(return_value=(1920, 1200, 0, 0, 1920, 1200)),
+            rotation=Mock(return_value=0),
+        )
+
+        with (
+            patch.object(uinput_backend, "ecodes", ecodes),
+            patch.object(uinput_backend, "evdev", fake_evdev),
+            patch.object(
+                uinput_backend,
+                "UInput",
+                return_value=types.SimpleNamespace(device=None),
+            ),
+            patch("monitorize.input_bridge.uinput_backend.time.sleep"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "MONITORIZE_UINPUT_PERMISSION"):
+                UInputBackend(geom, Mock()).setup()
+
     def test_stylus_capabilities_include_tablet_metadata(self):
         ecodes = types.SimpleNamespace(
             EV_ABS=3,

--- a/monitorize.spec
+++ b/monitorize.spec
@@ -1,0 +1,106 @@
+Name:           monitorize
+Version:        0.2.7
+Release:        1%{?dist}
+Summary:        Linux to Android display bridge
+
+License:        AGPL-3.0-only
+URL:            https://github.com/vinnavannewton/project-monitorize
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  desktop-file-utils
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       gstreamer1
+Requires:       gstreamer1-plugin-openh264
+Requires:       gstreamer1-plugins-bad-free
+Requires:       gstreamer1-plugins-base
+Requires:       gstreamer1-plugins-good
+Requires:       gstreamer1-plugins-ugly-free
+Requires:       iproute
+Requires:       kmod
+Requires:       pipewire
+Requires:       python3-cryptography
+Requires:       python3-dbus
+Requires:       python3-evdev
+Requires:       python3-gobject
+Requires:       python3-pyqt6
+Requires:       python3-zeroconf
+Requires:       shadow-utils
+Requires:       systemd-udev
+Requires:       util-linux
+Requires:       xdg-desktop-portal
+
+Requires(pre):  shadow-utils
+Requires(post): kmod
+Requires(post): systemd-udev
+Requires(postun): systemd-udev
+
+Recommends:     android-tools
+Recommends:     kscreen
+Recommends:     xdg-desktop-portal-gnome
+Recommends:     xdg-desktop-portal-kde
+Recommends:     xdg-desktop-portal-wlr
+
+%description
+Monitorize turns an Android tablet, laptop, or PC into a secondary monitor for
+a Linux desktop. It supports KDE Plasma, GNOME, and Hyprland through PipeWire,
+desktop portals, GStreamer, and uinput.
+
+
+%prep
+%autosetup
+
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files monitorize
+
+install -Dpm 0644 packaging/fedora/monitorize.desktop \
+    %{buildroot}%{_datadir}/applications/monitorize.desktop
+install -Dpm 0644 linux/monitorize/assets/monitorize_desktop_logo.png \
+    %{buildroot}%{_datadir}/icons/hicolor/192x192/apps/monitorize.png
+install -Dpm 0644 packaging/fedora/70-monitorize-uinput.rules \
+    %{buildroot}%{_udevrulesdir}/70-monitorize-uinput.rules
+
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/monitorize.desktop
+
+
+%pre
+getent group monitorize >/dev/null || groupadd -r monitorize
+
+
+%post
+/usr/sbin/modprobe uinput >/dev/null 2>&1 || :
+/usr/bin/udevadm control --reload-rules >/dev/null 2>&1 || :
+/usr/bin/udevadm trigger --subsystem-match=misc --sysname-match=uinput >/dev/null 2>&1 || :
+
+
+%postun
+/usr/bin/udevadm control --reload-rules >/dev/null 2>&1 || :
+
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+%{_bindir}/monitorize
+%{_datadir}/applications/monitorize.desktop
+%{_datadir}/icons/hicolor/192x192/apps/monitorize.png
+%{_udevrulesdir}/70-monitorize-uinput.rules
+
+
+%changelog
+* Thu Jul 09 2026 Monitorize contributors <noreply@example.com> - 0.2.7-1
+- Initial Fedora Copr package.

--- a/packaging/fedora/70-monitorize-uinput.rules
+++ b/packaging/fedora/70-monitorize-uinput.rules
@@ -1,0 +1,3 @@
+KERNEL=="uinput", GROUP="monitorize", MODE="0660", OPTIONS+="static_node=uinput"
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="Monitorize-Touch", GROUP="monitorize", MODE="0660"
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="Monitorize-Stylus", GROUP="monitorize", MODE="0660"

--- a/packaging/fedora/monitorize.desktop
+++ b/packaging/fedora/monitorize.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Monitorize
+Comment=Linux to Android display bridge
+Exec=monitorize
+Icon=monitorize
+Terminal=false
+Categories=Utility;
+Keywords=monitor;display;tablet;android;screen;extend;mirror;streaming;
+StartupNotify=true
+StartupWMClass=monitorize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools >= 69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "monitorize"
+version = "0.2.7"
+description = "Turn an Android or Linux device into a secondary monitor for Linux"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "AGPL-3.0-only"
+authors = [{ name = "Monitorize contributors" }]
+dependencies = [
+    "PyQt6",
+    "cryptography",
+    "dbus-python",
+    "evdev",
+    "PyGObject",
+    "zeroconf",
+]
+
+[project.scripts]
+monitorize = "monitorize.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["linux"]
+include = ["monitorize*"]
+
+[tool.setuptools.package-data]
+monitorize = [
+    "assets/*",
+    "assets/svg/*",
+    "assets/tray/*",
+    "qml/*.qml",
+]


### PR DESCRIPTION
## Summary by Sourcery

Introduce Fedora desktop packaging and Copr-based CI/CD for the Monitorize desktop app, while improving input permission handling, autostart behavior, and status reporting.

New Features:
- Add Fedora RPM/SRPM packaging for the desktop app via spec file, pyproject configuration, Copr Makefile, udev rules, and desktop entry.
- Enable system desktop entry usage for autostart when installed via RPM, including tray-agent integration.
- Add explicit input permission guidance surfaced in the desktop UI when uinput access is missing.

Bug Fixes:
- Prevent KDE setup failures when uinput event nodes are missing by raising clearer runtime errors tied to permission issues.
- Ensure advertised streaming FPS is a stable, configured value instead of a hardcoded fallback.
- Correct Android UI status text for video surface rendering timeouts.

Enhancements:
- Improve input backend error handling by mapping common uinput-related OS errors to a user-friendly permission hint.
- Update input reading in the desktop controller to parse process output once and to propagate permission hints into status messages.

Build:
- Add pyproject.toml and Copr Makefile to build Python wheels and SRPM/RPM artifacts for the desktop application.
- Introduce a Fedora spec file defining runtime and build dependencies, scripts, and packaging metadata for Monitorize.
- Add udev rules for uinput and group creation hooks required by the packaged desktop app.

CI:
- Create a Desktop GitHub Actions workflow to run Fedora-based CI, validate versions and packaging, build RPM/SRPM artifacts, publish desktop releases, and submit builds to Copr.
- Adjust Android CI workflow to use android-specific version tags and validation aligned with Gradle versionName.

Documentation:
- Update README with Fedora Copr installation instructions and clearer Android release tag guidance.

Tests:
- Extend desktop tests to cover RPM-installed autostart behavior, KDE input permission hint propagation, and KDE missing event node handling in the input backend.

Chores:
- Add initial Fedora Copr configuration for automated desktop releases and package publishing.