### PR TITLE
updating testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -136,11 +136,13 @@ jobs:
             gh release edit "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
               --notes "Monitorize Android $GITHUB_REF_NAME" \
-              --draft=false
+              --draft=false \
+              --latest
           else
             gh release create "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
-              --notes "Monitorize Android $GITHUB_REF_NAME"
+              --notes "Monitorize Android $GITHUB_REF_NAME" \
+              --latest
           fi
 
       - name: Upload APK to GitHub release

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -112,19 +112,21 @@ jobs:
           set -euo pipefail
           printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/android-release.jks"
 
-      - name: Build signed release APK
+      - name: Build signed release artifacts
         env:
           ANDROID_RELEASE_KEYSTORE: ${{ runner.temp }}/android-release.jks
           ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
           ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
           ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon :app:assembleRelease
+        run: ./gradlew --no-daemon :app:assembleRelease :app:bundleRelease
 
-      - name: Upload signed APK artifact
+      - name: Upload signed release artifacts
         uses: actions/upload-artifact@v4
         with:
           name: monitorize-android-${{ github.ref_name }}
-          path: android/app/build/outputs/apk/release/*.apk
+          path: |
+            android/app/build/outputs/apk/release/*.apk
+            android/app/build/outputs/bundle/release/*.aab
           if-no-files-found: error
 
       - name: Create GitHub release
@@ -149,3 +151,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "$GITHUB_REF_NAME" app/build/outputs/apk/release/*.apk --clobber
+
+      - name: Check Google Play service account
+        id: google_play
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not set; skipping Google Play upload."
+          fi
+
+      - name: Upload AAB to Google Play internal track
+        if: steps.google_play.outputs.available == 'true'
+        uses: r0adkll/upload-google-play@v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: app.monitorize.android
+          releaseFiles: android/app/build/outputs/bundle/release/*.aab
+          tracks: internal
+          status: completed
+          releaseName: ${{ github.ref_name }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -135,7 +135,8 @@ jobs:
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release edit "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
-              --notes "Monitorize Android $GITHUB_REF_NAME"
+              --notes "Monitorize Android $GITHUB_REF_NAME" \
+              --draft=false
           else
             gh release create "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -175,11 +175,13 @@ jobs:
             gh release edit "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
               --notes "$NOTES" \
-              --draft=false
+              --draft=false \
+              --latest=false
           else
             gh release create "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
-              --notes "$NOTES"
+              --notes "$NOTES" \
+              --latest=false
           fi
 
       - name: Upload RPMs to GitHub release

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Validate desktop version
         run: |
           set -euo pipefail

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -174,7 +174,8 @@ jobs:
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release edit "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
-              --notes "$NOTES"
+              --notes "$NOTES" \
+              --draft=false
           else
             gh release create "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -63,6 +63,7 @@ jobs:
             python3-gobject \
             python3-pip \
             python3-pyqt6 \
+            python3-setuptools \
             python3-wheel \
             python3-zeroconf \
             rpm-build \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -67,6 +67,7 @@ jobs:
             python3-wheel \
             python3-zeroconf \
             rpm-build \
+            systemd-rpm-macros \
             systemd-udev \
             util-linux \
             xdg-desktop-portal

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -35,13 +35,13 @@ val hasReleaseSigning = listOf(
 ).all { !it.isNullOrBlank() }
 
 android {
-    namespace = "com.example.monitorize"
+    namespace = "app.monitorize.android"
     compileSdk {
         version = release(36)
     }
 
     defaultConfig {
-        applicationId = "com.example.monitorize"
+        applicationId = "app.monitorize.android"
         minSdk = 28
         targetSdk = 36
         versionCode = versionCodeFromSemver(appVersionName)

--- a/android/app/src/main/java/app/monitorize/android/MainActivity.kt
+++ b/android/app/src/main/java/app/monitorize/android/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize
+package app.monitorize.android
 
 import android.content.Context
 import android.content.Intent
@@ -46,18 +46,18 @@ import androidx.compose.ui.zIndex
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import com.example.monitorize.discovery.DeviceDiscovery
-import com.example.monitorize.discovery.DiscoveredDevice
-import com.example.monitorize.input.InputEventSender
-import com.example.monitorize.streaming.H264Decoder
-import com.example.monitorize.streaming.StreamReceiver
-import com.example.monitorize.ui.theme.BreezeAccent as AccentIndigo
-import com.example.monitorize.ui.theme.BreezeBackground as BackgroundDark
-import com.example.monitorize.ui.theme.BreezeBorder as BorderDark
-import com.example.monitorize.ui.theme.BreezeButton as GreenAccent
-import com.example.monitorize.ui.theme.BreezeSurface as CardDark
-import com.example.monitorize.ui.theme.BreezeTextMuted as TextMuted
-import com.example.monitorize.ui.theme.MonitorizeTheme
+import app.monitorize.android.discovery.DeviceDiscovery
+import app.monitorize.android.discovery.DiscoveredDevice
+import app.monitorize.android.input.InputEventSender
+import app.monitorize.android.streaming.H264Decoder
+import app.monitorize.android.streaming.StreamReceiver
+import app.monitorize.android.ui.theme.BreezeAccent as AccentIndigo
+import app.monitorize.android.ui.theme.BreezeBackground as BackgroundDark
+import app.monitorize.android.ui.theme.BreezeBorder as BorderDark
+import app.monitorize.android.ui.theme.BreezeButton as GreenAccent
+import app.monitorize.android.ui.theme.BreezeSurface as CardDark
+import app.monitorize.android.ui.theme.BreezeTextMuted as TextMuted
+import app.monitorize.android.ui.theme.MonitorizeTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/android/app/src/main/java/app/monitorize/android/StreamDefaults.kt
+++ b/android/app/src/main/java/app/monitorize/android/StreamDefaults.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize
+package app.monitorize.android
 
 
 const val DEFAULT_STREAM_FPS = 60

--- a/android/app/src/main/java/app/monitorize/android/discovery/DeviceDiscovery.kt
+++ b/android/app/src/main/java/app/monitorize/android/discovery/DeviceDiscovery.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.discovery
+package app.monitorize.android.discovery
 
 import android.content.Context
 import android.net.nsd.NsdManager
@@ -6,9 +6,9 @@ import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
 import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
-import com.example.monitorize.DEFAULT_STREAM_FPS
-import com.example.monitorize.MAX_STREAM_FPS
-import com.example.monitorize.MIN_STREAM_FPS
+import app.monitorize.android.DEFAULT_STREAM_FPS
+import app.monitorize.android.MAX_STREAM_FPS
+import app.monitorize.android.MIN_STREAM_FPS
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ChannelResult

--- a/android/app/src/main/java/app/monitorize/android/input/InputEventSender.kt
+++ b/android/app/src/main/java/app/monitorize/android/input/InputEventSender.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.input
+package app.monitorize.android.input
 
 import android.os.SystemClock
 import android.util.Log

--- a/android/app/src/main/java/app/monitorize/android/security/SecureSocket.kt
+++ b/android/app/src/main/java/app/monitorize/android/security/SecureSocket.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.security
+package app.monitorize.android.security
 
 import android.annotation.SuppressLint
 import java.net.InetSocketAddress

--- a/android/app/src/main/java/app/monitorize/android/streaming/H264Decoder.kt
+++ b/android/app/src/main/java/app/monitorize/android/streaming/H264Decoder.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.streaming
+package app.monitorize.android.streaming
 
 import android.media.MediaCodec
 import android.media.MediaCodecInfo

--- a/android/app/src/main/java/app/monitorize/android/streaming/StreamReceiver.kt
+++ b/android/app/src/main/java/app/monitorize/android/streaming/StreamReceiver.kt
@@ -1,8 +1,8 @@
-package com.example.monitorize.streaming
+package app.monitorize.android.streaming
 
 import android.util.Log
-import com.example.monitorize.security.connectTls
-import com.example.monitorize.security.readAsciiLine
+import app.monitorize.android.security.connectTls
+import app.monitorize.android.security.readAsciiLine
 import java.net.Socket
 import java.net.InetSocketAddress
 import java.net.SocketTimeoutException

--- a/android/app/src/main/java/app/monitorize/android/ui/theme/Color.kt
+++ b/android/app/src/main/java/app/monitorize/android/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.ui.theme
+package app.monitorize.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/android/app/src/main/java/app/monitorize/android/ui/theme/Theme.kt
+++ b/android/app/src/main/java/app/monitorize/android/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.example.monitorize.ui.theme
+package app.monitorize.android.ui.theme
 
 import android.os.Build
 import androidx.compose.material3.MaterialTheme

--- a/monitorize.spec
+++ b/monitorize.spec
@@ -12,6 +12,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  python3-devel
 BuildRequires:  python3-wheel
 BuildRequires:  pyproject-rpm-macros
+BuildRequires:  systemd-rpm-macros
 
 Requires:       gstreamer1
 Requires:       gstreamer1-plugin-openh264


### PR DESCRIPTION
## Summary by Sourcery

Standardize the Android app package/namespace and extend release workflows to publish both mobile and desktop artifacts with improved release metadata and RPM build requirements.

Enhancements:
- Rename Android applicationId and namespaces from the example package to the production app.monitorize.android package.
- Add systemd RPM macros as a build requirement in the desktop RPM spec to support systemd integration.

Build:
- Update Android CI workflow to build and upload both APK and AAB artifacts and optionally publish AABs to Google Play internal track.
- Adjust GitHub release steps for Android and desktop to control draft/latest flags and improve release behavior.

CI:
- Add additional packages and safe Git configuration to the desktop GitHub Actions workflow to support RPM builds and trusted checkouts.

Deployment:
- Configure Google Play upload via service account for Android internal track releases.