### PR TITLE
fix(nix): patch KDE virtual output build script shebang

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -35,6 +35,7 @@ python3Packages.buildPythonApplication rec {
     gobject-introspection
     pkg-config
     wayland
+    bash
   ];
 
   buildInputs = [
@@ -82,6 +83,9 @@ python3Packages.buildPythonApplication rec {
     exec ${python}/bin/python3 -m monitorize "\$@"
     WRAPPER
     chmod +x "$out/bin/monitorize"
+
+    # Patch /usr/bin/env shebang before executing the script.
+    patchShebangs native/kde_virtual_output/build.sh
 
     # Native KWin virtual-output owner. The hidden desktop entry below grants
     # this exact executable access to KWin's restricted screencast protocol.


### PR DESCRIPTION
## What does this PR do?

Fixes the Nix build of Monitorize's KDE virtual output helper.

## Problem

The `native/kde_virtual_output/build.sh` script uses:

    #!/usr/bin/env bash

During the Nix build, the script is executed directly during `installPhase`.
The `/usr/bin/env` interpreter is not available inside the Nix build sandbox,
causing the build to fail with:

    /usr/bin/env: bad interpreter: No such file or directory

## Fix

Patch the script's shebang with `patchShebangs` before executing it.

This allows Nix to use the Bash interpreter from the Nix store.

## Testing

Tested with:

    nix build .#monitorize

The package builds successfully and Monitorize starts correctly.

## Summary by Sourcery

Ensure Monitorize’s KDE virtual output helper builds correctly under Nix by patching its build script shebang before execution.

Build:
- Add Bash as a native build input for the Nix package to provide an interpreter within the sandbox.
- Patch the KDE virtual output helper build script shebang during install to avoid reliance on /usr/bin/env in Nix builds.