### PR TITLE
fix(kde): pass direct PipeWire screencast node to Sunshine on KDE Way…

### DIFF
--- a/linux/monitorize/desktop/streaming_controller.py
+++ b/linux/monitorize/desktop/streaming_controller.py
@@ -250,7 +250,7 @@ class StreamingController(QObject):
             output_name,
             width,
             height,
-            pipewire_node=event.get("node_id") if self.de == "gnome" else None,
+            pipewire_node=event.get("node_id"),
             offset_x=int(event.get("offset_x") or 0),
             offset_y=int(event.get("offset_y") or 0),
         ):
@@ -299,20 +299,19 @@ class StreamingController(QObject):
         save_sunshine_config(
             {"stream_audio": "enabled" if audio else "disabled"}, instance=instance
         )
-        if not is_sunshine_running(instance):
-            ok, message = start_sunshine(
-                instance,
-                pipewire_node=pipewire_node,
-                offset_x=offset_x,
-                offset_y=offset_y,
-                width=width,
-                height=height,
-            )
-            if not ok:
-                self._set_status(message)
-                self.logAppended.emit("SUNSHINE", f"ERROR: {message}")
-                return False
-            self.logAppended.emit("SUNSHINE", message)
+        ok, message = start_sunshine(
+            instance,
+            pipewire_node=pipewire_node,
+            offset_x=offset_x,
+            offset_y=offset_y,
+            width=width,
+            height=height,
+        )
+        if not ok:
+            self._set_status(message)
+            self.logAppended.emit("SUNSHINE", f"ERROR: {message}")
+            return False
+        self.logAppended.emit("SUNSHINE", message)
         QTimer.singleShot(1500, self.sunshine_watchdog_timer.start)
         return True
 

--- a/linux/monitorize/platform/sunshine_service.py
+++ b/linux/monitorize/platform/sunshine_service.py
@@ -393,7 +393,24 @@ def start_sunshine(
         )
 
     if is_sunshine_running(instance):
-        return True, f"Sunshine instance {instance} is already running."
+        target_node = _SUNSHINE_PIPEWIRE_NODES.get(instance)
+        running_proc = _SUNSHINE_PROCESSES.get(instance) or (_SUNSHINE_PROCESS if instance == 1 else None)
+        needs_restart = False
+        if target_node:
+            if running_proc and running_proc.pid:
+                try:
+                    with open(f"/proc/{running_proc.pid}/environ", "rb") as f:
+                        env_data = f.read().decode("utf-8", errors="ignore")
+                        if f"SUNSHINE_PIPEWIRE_NODE={target_node}" not in env_data:
+                            needs_restart = True
+                except Exception:
+                    needs_restart = True
+            else:
+                needs_restart = True
+        if needs_restart:
+            stop_sunshine(instance)
+        else:
+            return True, f"Sunshine instance {instance} is already running."
 
     try:
         from monitorize.platform.gnome_virtual_monitor import map_sunshine_gnome_peripherals

--- a/linux/monitorize/streaming/headless_virtual_display.py
+++ b/linux/monitorize/streaming/headless_virtual_display.py
@@ -40,6 +40,54 @@ def _emit_event(event: dict):
     print(f"MONITORIZE_EVENT {json.dumps(event, separators=(',', ':'))}", flush=True)
 
 
+def _find_kwin_screencast_node(output_name, timeout=5.0):
+    """Find the PipeWire node ID for KWin's screencast of the given output.
+
+    KWin creates PipeWire screencast nodes named ``kwin-screencast-<output>``
+    for each active output. This function polls ``pw-dump`` until the node
+    appears or *timeout* seconds elapse.
+
+    Returns the integer node ID, or 0 if not found.
+    """
+    exact_media_name = f"kwin-screencast-{output_name}".lower()
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["pw-dump"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if result.returncode == 0:
+                nodes = json.loads(result.stdout)
+                # First pass: look for exact media.name match with Stream/Output/Video
+                for obj in nodes:
+                    if obj.get("type") != "PipeWire:Interface:Node":
+                        continue
+                    props = obj.get("info", {}).get("props", {})
+                    media_name = str(props.get("media.name") or "").lower()
+                    media_class = str(props.get("media.class") or "")
+                    if media_name == exact_media_name and media_class == "Stream/Output/Video":
+                        return int(obj.get("id", 0))
+
+                # Second pass: look for partial match in media.name or node.description
+                for obj in nodes:
+                    if obj.get("type") != "PipeWire:Interface:Node":
+                        continue
+                    props = obj.get("info", {}).get("props", {})
+                    media_name = str(props.get("media.name") or "").lower()
+                    media_class = str(props.get("media.class") or "")
+                    node_desc = str(props.get("node.description") or "").lower()
+                    if media_class == "Stream/Output/Video":
+                        if output_name.lower() in media_name or output_name.lower() in node_desc:
+                            return int(obj.get("id", 0))
+        except Exception:
+            pass
+        time.sleep(0.3)
+
+    return 0
+
+
 def run_kde_headless(slot, width, height, fps):
     slot_info = virtual_slot(slot)
     output_name = slot_info["output_name"]
@@ -86,9 +134,15 @@ def run_kde_headless(slot, width, height, fps):
             raise RuntimeError(message)
 
         print(f"[Headless] {message}", flush=True)
+        node_id = _find_kwin_screencast_node(actual_name)
+        if node_id:
+            print(f"[Headless] Found PipeWire screencast node {node_id} for {actual_name}", flush=True)
+        else:
+            print(f"[Headless] Warning: no PipeWire screencast node found for {actual_name}", flush=True)
         _emit_event({
             "type": "headless_ready",
             "name": actual_name,
+            "node_id": node_id,
             "width": actual.get("width", width),
             "height": actual.get("height", height),
             "fps": actual.get("refresh_rate", fps),


### PR DESCRIPTION
…land

- Detect KWin's native PipeWire screencast node for virtual displays via pw-dump
- Emit node_id in KDE headless_ready event
- Pass pipewire_node to Sunshine on KDE instead of only GNOME
- Ensure Sunshine restarts if target PipeWire node changed or was unset

## Summary by Sourcery

Support direct PipeWire screencast nodes for KDE Wayland virtual-display streaming and keep Sunshine aligned with the active node.

New Features:
- Detect and report KWin PipeWire screencast nodes for KDE virtual displays.

Bug Fixes:
- Pass the display-specific PipeWire node to Sunshine on KDE and restart Sunshine when its configured target node changes or is unavailable.